### PR TITLE
uses 32-bit (de)allocators

### DIFF
--- a/modules/structs/dynamic/linked-list/LinkedList.for
+++ b/modules/structs/dynamic/linked-list/LinkedList.for
@@ -26,7 +26,7 @@
 module linkedlists
     use, intrinsic :: iso_fortran_env, only: int32, int64
     use utils, only: reallocator => util_reallocate_array
-    use utils, only: deallocate_array => util_deallocate_array
+    use utils, only: deallocate_array => util_deallocate_array_int32
     implicit none
 
 


### PR DESCRIPTION
now that there's more than one version it was necessary to state which of the (de)allocators are needed (for a successful build)