### PR TITLE
implements fill constructor [vector]

### DIFF
--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -23,6 +23,38 @@
 !   You should have received a copy of the GNU General Public License
 !   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+module bits
+use, intrinsic :: iso_fortran_env, only: int32, int64
+implicit none
+private
+save
+public :: BITS_MAX_BIT
+public :: imsb
+
+integer(kind = int32), parameter :: BITS_MAX_BIT = 63
+
+contains
+
+  pure function imsb (n) result(msb)
+      ! Synopsis:
+      ! Finds the Most Significant Bit MSB of a 64-bit (signed) integer.
+      integer(kind = int64), intent(in) :: n    !! 64-bit integer
+      integer(kind = int32) :: pos              !! position
+      integer(kind = int32) :: msb              !! most significant bit
+
+      msb = 0
+      do pos = 0, 63
+          if ( btest(n, pos) ) then
+              msb = pos
+          end if
+      end do
+
+      return
+  end function
+
+end module bits
+
+
 module idata
   ! Defines the type i[nternal]data of the vector class
   use, intrinsic :: iso_fortran_env, only: int32, int64

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -174,6 +174,7 @@ module VectorClass
                                       & vector_vector_t_push_back_method
         procedure, public :: size => size_method
         procedure, public :: clear => clear_method
+        procedure, public :: addr => vector_print_container_address_method
         final :: finalizer
   end type
 
@@ -183,6 +184,7 @@ module VectorClass
       module procedure vector_int32_t_fillConstructor
       module procedure vector_int64_t_fillConstructor
       module procedure vector_real64_t_fillConstructor
+      module procedure vector_vector_t_fillConstructor
   end interface
 
 
@@ -287,6 +289,7 @@ module VectorClass
       module procedure vector_int32_t_push_n_copies
       module procedure vector_int64_t_push_n_copies
       module procedure vector_real64_t_push_n_copies
+      module procedure vector_vector_t_push_n_copies
       module procedure vector_int32_t_push_array
       module procedure vector_int64_t_push_array
       module procedure vector_real64_t_push_array
@@ -354,6 +357,13 @@ module VectorClass
         type(vector_t), allocatable :: vec
         integer(kind = int64), intent(in) :: n
         real(kind = real64), intent(in) :: value
+    end function
+
+
+    module function vector_vector_t_fillConstructor (n, value) result(vec)
+        type(vector_t), allocatable :: vec
+        type(vector_t), intent(in) :: value
+        integer(kind = int64), intent(in) :: n
     end function
 
 
@@ -459,6 +469,12 @@ module VectorClass
     module subroutine clear_method (self)
         ! Synopsis: Clears the vector elements.
         class(vector_t), intent(inout) :: self
+    end subroutine
+
+
+    module subroutine vector_print_container_address_method (self)
+        ! Synopsis: Prints the addresses of the internal array and iterator.
+        class(vector_t), intent(in) :: self
     end subroutine
 
 
@@ -656,6 +672,13 @@ module VectorClass
         type(vector_t), intent(inout), target :: vector
         integer(kind = int64), intent(in) :: n
         real(kind = real64), intent(in) :: value
+    end subroutine
+
+
+    module subroutine vector_vector_t_push_n_copies (vector, n, value)
+        type(vector_t), intent(inout), target :: vector
+        type(vector_t), intent(in) :: value
+        integer(kind = int64), intent(in) :: n
     end subroutine
 
 

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -180,6 +180,7 @@ module VectorClass
 
   interface vector_t
       module procedure default_constructor
+      module procedure vector_int32_t_fillConstructor
   end interface
 
 
@@ -281,6 +282,7 @@ module VectorClass
       module procedure vector_int64_t_push
       module procedure vector_real64_t_push
       module procedure vector_vector_t_push
+      module procedure vector_int32_t_push_n_copies
       module procedure vector_int32_t_push_array
       module procedure vector_int64_t_push_array
       module procedure vector_real64_t_push_array
@@ -327,6 +329,13 @@ module VectorClass
     module function default_constructor () result(vector)
         ! Synopsis: Returns an empty vector
         type(vector_t):: vector
+    end function
+
+
+    module function vector_int32_t_fillConstructor (n, value) result(vec)
+        type(vector_t), allocatable :: vec
+        integer(kind = int64), intent(in) :: n
+        integer(kind = int32), intent(in) :: value
     end function
 
 
@@ -608,6 +617,13 @@ module VectorClass
     module subroutine vector_vector_t_push (vector, value)
         type(vector_t), intent(inout), target :: vector
         type(vector_t), intent(in) :: value
+    end subroutine
+
+
+    module pure subroutine vector_int32_t_push_n_copies (vector, n, value)
+        type(vector_t), intent(inout), target :: vector
+        integer(kind = int64), intent(in) :: n
+        integer(kind = int32), intent(in) :: value
     end subroutine
 
 

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -113,6 +113,8 @@ module VectorClass
   use utils, only: util_reallocate_array_int32_by_bounds
   use utils, only: util_deallocate_array_int32
   use utils, only: util_deallocate_array_int64
+  use bits,  only: BITS_MAX_BIT
+  use bits,  only: imsb
   use idata, only: data_t
   implicit none
   private
@@ -305,6 +307,11 @@ module VectorClass
       module procedure vector_int64_t_restore
       module procedure vector_real64_t_restore
       module procedure vector_vector_t_restore
+  end interface
+
+
+  interface double
+      module procedure double_vector_size
   end interface
 
 
@@ -914,6 +921,11 @@ module VectorClass
     module subroutine check_bounds (vector, idx)
         type(vector_t), intent(in) :: vector
         integer(kind = int64), intent(in) :: idx
+    end subroutine
+
+
+    module pure subroutine double_vector_size (vector)
+        type(vector_t), intent(inout) :: vector
     end subroutine
 
 

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -90,6 +90,8 @@ module VectorClass
   type :: iter_t
       class(*), pointer, contiguous :: it(:) => null()
       integer(kind = int64) :: idx = 0_int64
+      contains
+        final :: destructor_iter_t
   end type
 
 
@@ -893,6 +895,11 @@ module VectorClass
 !       integer(kind = int64), intent(in) :: i
 !       character(len = 64) :: str
 !   end function
+
+
+    module subroutine destructor_iter_t (i)
+        type(iter_t), intent(inout) :: i
+    end subroutine
 
 
     module subroutine destructor_stat_t (s)

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -181,6 +181,7 @@ module VectorClass
   interface vector_t
       module procedure default_constructor
       module procedure vector_int32_t_fillConstructor
+      module procedure vector_int64_t_fillConstructor
   end interface
 
 
@@ -283,6 +284,7 @@ module VectorClass
       module procedure vector_real64_t_push
       module procedure vector_vector_t_push
       module procedure vector_int32_t_push_n_copies
+      module procedure vector_int64_t_push_n_copies
       module procedure vector_int32_t_push_array
       module procedure vector_int64_t_push_array
       module procedure vector_real64_t_push_array
@@ -336,6 +338,13 @@ module VectorClass
         type(vector_t), allocatable :: vec
         integer(kind = int64), intent(in) :: n
         integer(kind = int32), intent(in) :: value
+    end function
+
+
+    module function vector_int64_t_fillConstructor (n, value) result(vec)
+        type(vector_t), allocatable :: vec
+        integer(kind = int64), intent(in) :: n
+        integer(kind = int64), intent(in) :: value
     end function
 
 
@@ -624,6 +633,13 @@ module VectorClass
         type(vector_t), intent(inout), target :: vector
         integer(kind = int64), intent(in) :: n
         integer(kind = int32), intent(in) :: value
+    end subroutine
+
+
+    module pure subroutine vector_int64_t_push_n_copies (vector, n, value)
+        type(vector_t), intent(inout), target :: vector
+        integer(kind = int64), intent(in) :: n
+        integer(kind = int64), intent(in) :: value
     end subroutine
 
 

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -182,6 +182,7 @@ module VectorClass
       module procedure default_constructor
       module procedure vector_int32_t_fillConstructor
       module procedure vector_int64_t_fillConstructor
+      module procedure vector_real64_t_fillConstructor
   end interface
 
 
@@ -285,6 +286,7 @@ module VectorClass
       module procedure vector_vector_t_push
       module procedure vector_int32_t_push_n_copies
       module procedure vector_int64_t_push_n_copies
+      module procedure vector_real64_t_push_n_copies
       module procedure vector_int32_t_push_array
       module procedure vector_int64_t_push_array
       module procedure vector_real64_t_push_array
@@ -345,6 +347,13 @@ module VectorClass
         type(vector_t), allocatable :: vec
         integer(kind = int64), intent(in) :: n
         integer(kind = int64), intent(in) :: value
+    end function
+
+
+    module function vector_real64_t_fillConstructor (n, value) result(vec)
+        type(vector_t), allocatable :: vec
+        integer(kind = int64), intent(in) :: n
+        real(kind = real64), intent(in) :: value
     end function
 
 
@@ -640,6 +649,13 @@ module VectorClass
         type(vector_t), intent(inout), target :: vector
         integer(kind = int64), intent(in) :: n
         integer(kind = int64), intent(in) :: value
+    end subroutine
+
+
+    module pure subroutine vector_real64_t_push_n_copies (vector, n, value)
+        type(vector_t), intent(inout), target :: vector
+        integer(kind = int64), intent(in) :: n
+        real(kind = real64), intent(in) :: value
     end subroutine
 
 

--- a/modules/structs/dynamic/vector/Vector.for
+++ b/modules/structs/dynamic/vector/Vector.for
@@ -730,6 +730,11 @@ module VectorClass
     end subroutine
 
 
+    module recursive subroutine vector_validate_iterator (vector)
+        type(vector_t), intent(inout), target :: vector
+    end subroutine
+
+
     module subroutine vector_int32_t_initializer (vector, value)
         type(vector_t), intent(inout) :: vector
         integer(kind = int32), intent(in) :: value

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
@@ -28,6 +28,45 @@ implicit none
 contains
 
 
+  module function vector_int32_t_fillConstructor (n, value) result(vec)
+      type(vector_t), allocatable :: vec
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64) :: bounds(0:1)
+      integer(kind = int32), intent(in) :: value
+      integer(kind = int32) :: mstat
+      character(*), parameter :: errMSG = &
+          & "vector(): the number of copies must be positive integer"
+
+      call check !! caters silly requests
+
+      allocate (vec, stat=mstat)
+      if (mstat /= 0) error stop 'memory allocation error'
+
+      call instantiate (vec)
+
+      ! sets the vector limits
+      vec % limit % idx = n
+      call double (vec)
+
+      bounds(0) = 0_int64
+      bounds(1) = vec % limit % idx
+      call allocator (bounds, vec % array % values, value)
+
+      ! pushes `n' copies of the value `value' unto vector
+      call push (vec, n, value)
+
+      vec % state % init = .true.
+
+      return
+      contains
+          subroutine check
+              if (n <= 0_int64) then
+                  error stop errMSG
+              end if
+          end subroutine
+  end function vector_int32_t_fillConstructor
+
+
   module subroutine vector_int32_t_findloc_wrapper (vector, value, i)
       type(vector_t), intent(in) :: vector
       integer(kind = int64), intent(out) :: i

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
@@ -40,25 +40,16 @@ contains
       character(len=*), parameter :: name = 'dynamic::vector.error:'
       character(len=*), parameter :: errmsg_i32 = name // ' ' // &
           & 'container of 32-bit integers'
-      character(len=*), parameter :: errmsg_i64 = name // ' ' // &
-          & 'container of 64-bit integers'
-      character(len=*), parameter :: errmsg_r64 = name // ' ' // &
-          & 'container of 64-bit reals'
-      character(len=*), parameter :: errmsg_vec = name // ' ' // &
-          & 'container of vectors'
       character(len=*), parameter :: unimplmntd = name // ' ' // &
           & 'unimplemented vector<T>'
 
       call check                !! complains on invalid inputs
       call alloc                !! allocates memory for vector
-      call instantiate (vec)    !! initializes the vector components
+      call init                 !! initializes the vector components
       call tailor               !! tailors the vector to store `n' copies
       call error                !! sets the internal error message
-
-
-      ! pushes `n' copies of the value `value' unto vector
-      call push (vec, n, value)
-
+      call insert               !! pushes `n' copies of `value' unto vector
+      call valid                !! validates iterator(s)
 
       vec % state % init = .true.
 
@@ -88,6 +79,15 @@ contains
           end subroutine
 
 
+          subroutine init
+              ! provides initial values to the vector components
+
+              call instantiate (vec)
+
+              return
+          end subroutine
+
+
           subroutine tailor
               ! tailors the vector size based on the number of copies
 
@@ -107,34 +107,34 @@ contains
 
               associate (values => vec % array % values)
                   select type (values)
-
                       type is ( integer(kind = int32) )
-
                           call allocator      (vec, errmsg_i32)
                           vec % state % errmsg(:) = errmsg_i32
-
-                      type is ( integer(kind = int64) )
-
-                          call allocator      (vec, errmsg_i64)
-                          vec % state % errmsg(:) = errmsg_i64
-
-                      type is ( real(kind = real64) )
-
-                          call allocator      (vec, errmsg_r64)
-                          vec % state % errmsg(:) = errmsg_r64
-
-                      type is (vector_t)
-                          call allocator      (vec, errmsg_vec)
-                          vec % state % errmsg(:) = errmsg_vec
-
                       class default
                           error stop unimplmntd
-
                   end select
               end associate
 
               return
           end subroutine error
+
+
+          subroutine insert
+              ! inserts values unto the back of vector
+
+              call push (vec, n, value)
+
+              return
+          end subroutine
+
+
+          subroutine valid
+              ! validates iterators by re-associating them
+
+              call vector_validate_iterator (vec)
+
+              return
+          end subroutine
 
   end function vector_int32_t_fillConstructor
 

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
@@ -29,41 +29,66 @@ contains
 
 
   module function vector_int32_t_fillConstructor (n, value) result(vec)
+      ! Synopsis: Creates a vector having `n' copies of `value'.
       type(vector_t), allocatable :: vec
       integer(kind = int64), intent(in) :: n
       integer(kind = int64) :: bounds(0:1)
       integer(kind = int32), intent(in) :: value
       integer(kind = int32) :: mstat
       character(*), parameter :: errMSG = &
-          & "vector(): the number of copies must be positive integer"
+          & "vector(): the number of copies must be a positive integer"
 
-      call check !! caters silly requests
+      call check                !! complains on invalid inputs
+      call alloc                !! allocates memory for vector
+      call instantiate (vec)    !! initializes the vector components
+      call tailor               !! tailors the vector to store `n' copies
 
-      allocate (vec, stat=mstat)
-      if (mstat /= 0) error stop 'memory allocation error'
-
-      call instantiate (vec)
-
-      ! sets the vector limits
-      vec % limit % idx = n
-      call double (vec)
-
-      bounds(0) = 0_int64
-      bounds(1) = vec % limit % idx
-      call allocator (bounds, vec % array % values, value)
 
       ! pushes `n' copies of the value `value' unto vector
       call push (vec, n, value)
+
 
       vec % state % init = .true.
 
       return
       contains
+
           subroutine check
+              ! complains on invalid input
+
               if (n <= 0_int64) then
                   error stop errMSG
               end if
+
+              return
           end subroutine
+
+
+          subroutine alloc
+              ! allocates memory for a vector
+
+              allocate (vec, stat=mstat)
+              if (mstat /= 0) then
+                  error stop 'vector(): memory allocation error'
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine tailor
+              ! tailors the vector size based on the number of copies
+
+              vec % limit % idx = n     !! sets the vector `limit' to fit
+              call double (vec)         !! and doubles it for convenience
+
+              bounds(0) = 0_int64
+              bounds(1) = vec % limit % idx
+              call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
   end function vector_int32_t_fillConstructor
 
 

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
@@ -37,11 +37,23 @@ contains
       integer(kind = int64) :: bounds(0:1)
       character(*), parameter :: errMSG = &
           & "vector(): the number of copies must be a positive integer"
+      character(len=*), parameter :: name = 'dynamic::vector.error:'
+      character(len=*), parameter :: errmsg_i32 = name // ' ' // &
+          & 'container of 32-bit integers'
+      character(len=*), parameter :: errmsg_i64 = name // ' ' // &
+          & 'container of 64-bit integers'
+      character(len=*), parameter :: errmsg_r64 = name // ' ' // &
+          & 'container of 64-bit reals'
+      character(len=*), parameter :: errmsg_vec = name // ' ' // &
+          & 'container of vectors'
+      character(len=*), parameter :: unimplmntd = name // ' ' // &
+          & 'unimplemented vector<T>'
 
       call check                !! complains on invalid inputs
       call alloc                !! allocates memory for vector
       call instantiate (vec)    !! initializes the vector components
       call tailor               !! tailors the vector to store `n' copies
+      call error                !! sets the internal error message
 
 
       ! pushes `n' copies of the value `value' unto vector
@@ -88,6 +100,41 @@ contains
 
               return
           end subroutine
+
+
+          subroutine error
+              ! defines the internal error message of vector
+
+              associate (values => vec % array % values)
+                  select type (values)
+
+                      type is ( integer(kind = int32) )
+
+                          call allocator      (vec, errmsg_i32)
+                          vec % state % errmsg(:) = errmsg_i32
+
+                      type is ( integer(kind = int64) )
+
+                          call allocator      (vec, errmsg_i64)
+                          vec % state % errmsg(:) = errmsg_i64
+
+                      type is ( real(kind = real64) )
+
+                          call allocator      (vec, errmsg_r64)
+                          vec % state % errmsg(:) = errmsg_r64
+
+                      type is (vector_t)
+                          call allocator      (vec, errmsg_vec)
+                          vec % state % errmsg(:) = errmsg_vec
+
+                      class default
+                          error stop unimplmntd
+
+                  end select
+              end associate
+
+              return
+          end subroutine error
 
   end function vector_int32_t_fillConstructor
 

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_implementations.for
@@ -32,9 +32,9 @@ contains
       ! Synopsis: Creates a vector having `n' copies of `value'.
       type(vector_t), allocatable :: vec
       integer(kind = int64), intent(in) :: n
-      integer(kind = int64) :: bounds(0:1)
       integer(kind = int32), intent(in) :: value
       integer(kind = int32) :: mstat
+      integer(kind = int64) :: bounds(0:1)
       character(*), parameter :: errMSG = &
           & "vector(): the number of copies must be a positive integer"
 

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_push_back_methods.for
@@ -135,6 +135,41 @@ contains
   end subroutine vector_int32_t_push_array
 
 
+  module pure subroutine vector_int32_t_push_n_copies (vector, n, value)
+      ! Synopsis: pushes `n' copies of value unto the back of vector.
+      type(vector_t), intent(inout), target :: vector
+      integer(kind = int32), intent(in) :: value
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64) :: numel
+      integer(kind = int64) :: final
+
+
+      numel = n
+
+      associate (begin  => vector % begin % idx,  &
+               & avail  => vector % avail % idx,  &
+               & values => vector % array % values)
+
+          final = avail + numel - 1_int64
+
+          select type (values)
+              type is ( integer(kind = int32) )
+                  values (avail:final) = value
+              class default
+                  ! caters inserting mixed-types
+                  error stop vector % state % errmsg
+          end select
+
+          vector % deref % it => vector % array % values(begin:final)
+          avail = avail + numel
+
+      end associate
+
+
+      return
+  end subroutine vector_int32_t_push_n_copies
+
+
   module subroutine vector_int32_t_grow (vector, value)
       ! Synopsis: Doubles the vector size.
       type(vector_t), intent(inout) :: vector

--- a/modules/structs/dynamic/vector/submodules/Vector_int32_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int32_t_push_back_methods.for
@@ -142,9 +142,7 @@ contains
       integer(kind = int32), allocatable :: array(:)
 
       call backup  (vector, array)
-
-      vector % limit % idx = 2_int64 * vector % limit % idx !! doubles size
-
+      call double  (vector)
       call restore (vector, array, value)
 
       return

--- a/modules/structs/dynamic/vector/submodules/Vector_int64_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int64_t_implementations.for
@@ -28,6 +28,70 @@ implicit none
 contains
 
 
+  module function vector_int64_t_fillConstructor (n, value) result(vec)
+      ! Synopsis: Creates a vector having `n' copies of `value'.
+      type(vector_t), allocatable :: vec
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64), intent(in) :: value
+      integer(kind = int32) :: mstat
+      integer(kind = int64) :: bounds(0:1)
+      character(*), parameter :: errMSG = &
+          & "vector(): the number of copies must be a positive integer"
+
+      call check                !! complains on invalid inputs
+      call alloc                !! allocates memory for vector
+      call instantiate (vec)    !! initializes the vector components
+      call tailor               !! tailors the vector to store `n' copies
+
+
+      ! pushes `n' copies of the value `value' unto vector
+      call push (vec, n, value)
+
+
+      vec % state % init = .true.
+
+      return
+      contains
+
+          subroutine check
+              ! complains on invalid input
+
+              if (n <= 0_int64) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine alloc
+              ! allocates memory for a vector
+
+              allocate (vec, stat=mstat)
+              if (mstat /= 0) then
+                  error stop 'vector(): memory allocation error'
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine tailor
+              ! tailors the vector size based on the number of copies
+
+              vec % limit % idx = n     !! sets the vector `limit' to fit
+              call double (vec)         !! and doubles it for convenience
+
+              bounds(0) = 0_int64
+              bounds(1) = vec % limit % idx
+              call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
+  end function vector_int64_t_fillConstructor
+
+
   module subroutine vector_int64_t_findloc_wrapper (vector, value, i)
       type(vector_t), intent(in) :: vector
       integer(kind = int64), intent(out) :: i

--- a/modules/structs/dynamic/vector/submodules/Vector_int64_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int64_t_push_back_methods.for
@@ -135,6 +135,41 @@ contains
   end subroutine vector_int64_t_push_array
 
 
+  module pure subroutine vector_int64_t_push_n_copies (vector, n, value)
+      ! Synopsis: pushes `n' copies of value unto the back of vector.
+      type(vector_t), intent(inout), target :: vector
+      integer(kind = int64), intent(in) :: value
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64) :: numel
+      integer(kind = int64) :: final
+
+
+      numel = n
+
+      associate (begin  => vector % begin % idx,  &
+               & avail  => vector % avail % idx,  &
+               & values => vector % array % values)
+
+          final = avail + numel - 1_int64
+
+          select type (values)
+              type is ( integer(kind = int64) )
+                  values (avail:final) = value
+              class default
+                  ! caters inserting mixed-types
+                  error stop vector % state % errmsg
+          end select
+
+          vector % deref % it => vector % array % values(begin:final)
+          avail = avail + numel
+
+      end associate
+
+
+      return
+  end subroutine vector_int64_t_push_n_copies
+
+
   module subroutine vector_int64_t_grow (vector, value)
       ! Synopsis: Doubles the vector size.
       type(vector_t), intent(inout) :: vector

--- a/modules/structs/dynamic/vector/submodules/Vector_int64_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_int64_t_push_back_methods.for
@@ -142,9 +142,7 @@ contains
       integer(kind = int64), allocatable :: array(:)
 
       call backup  (vector, array)
-
-      vector % limit % idx = 2_int64 * vector % limit % idx !! doubles size
-
+      call double  (vector)
       call restore (vector, array, value)
 
       return

--- a/modules/structs/dynamic/vector/submodules/Vector_real64_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_real64_t_implementations.for
@@ -37,16 +37,19 @@ contains
       integer(kind = int64) :: bounds(0:1)
       character(*), parameter :: errMSG = &
           & "vector(): the number of copies must be a positive integer"
+      character(len=*), parameter :: name = 'dynamic::vector.error:'
+      character(len=*), parameter :: errmsg_r64 = name // ' ' // &
+          & 'container of 64-bit reals'
+      character(len=*), parameter :: unimplmntd = name // ' ' // &
+          & 'unimplemented vector<T>'
 
       call check                !! complains on invalid inputs
       call alloc                !! allocates memory for vector
-      call instantiate (vec)    !! initializes the vector components
+      call init                 !! initializes the vector components
       call tailor               !! tailors the vector to store `n' copies
-
-
-      ! pushes `n' copies of the value `value' unto vector
-      call push (vec, n, value)
-
+      call error                !! sets the internal error message
+      call insert               !! pushes `n' copies of `value' unto vector
+      call valid                !! validates iterator(s)
 
       vec % state % init = .true.
 
@@ -76,6 +79,15 @@ contains
           end subroutine
 
 
+          subroutine init
+              ! provides initial values to the vector components
+
+              call instantiate (vec)
+
+              return
+          end subroutine
+
+
           subroutine tailor
               ! tailors the vector size based on the number of copies
 
@@ -85,6 +97,41 @@ contains
               bounds(0) = 0_int64
               bounds(1) = vec % limit % idx
               call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
+
+          subroutine error
+              ! defines the internal error message of vector
+
+              associate (values => vec % array % values)
+                  select type (values)
+                      type is ( real(kind = real64) )
+                          call allocator      (vec, errmsg_r64)
+                          vec % state % errmsg(:) = errmsg_r64
+                      class default
+                          error stop unimplmntd
+                  end select
+              end associate
+
+              return
+          end subroutine error
+
+
+          subroutine insert
+              ! inserts values unto the back of vector
+
+              call push (vec, n, value)
+
+              return
+          end subroutine
+
+
+          subroutine valid
+              ! validates iterators by re-associating them
+
+              call vector_validate_iterator (vec)
 
               return
           end subroutine

--- a/modules/structs/dynamic/vector/submodules/Vector_real64_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_real64_t_implementations.for
@@ -28,6 +28,70 @@ implicit none
 contains
 
 
+  module function vector_real64_t_fillConstructor (n, value) result(vec)
+      ! Synopsis: Creates a vector having `n' copies of `value'.
+      type(vector_t), allocatable :: vec
+      integer(kind = int64), intent(in) :: n
+      real(kind = real64), intent(in) :: value
+      integer(kind = int32) :: mstat
+      integer(kind = int64) :: bounds(0:1)
+      character(*), parameter :: errMSG = &
+          & "vector(): the number of copies must be a positive integer"
+
+      call check                !! complains on invalid inputs
+      call alloc                !! allocates memory for vector
+      call instantiate (vec)    !! initializes the vector components
+      call tailor               !! tailors the vector to store `n' copies
+
+
+      ! pushes `n' copies of the value `value' unto vector
+      call push (vec, n, value)
+
+
+      vec % state % init = .true.
+
+      return
+      contains
+
+          subroutine check
+              ! complains on invalid input
+
+              if (n <= 0_int64) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine alloc
+              ! allocates memory for a vector
+
+              allocate (vec, stat=mstat)
+              if (mstat /= 0) then
+                  error stop 'vector(): memory allocation error'
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine tailor
+              ! tailors the vector size based on the number of copies
+
+              vec % limit % idx = n     !! sets the vector `limit' to fit
+              call double (vec)         !! and doubles it for convenience
+
+              bounds(0) = 0_int64
+              bounds(1) = vec % limit % idx
+              call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
+  end function vector_real64_t_fillConstructor
+
+
   module subroutine vector_real64_t_indexer (vector, idx, value)
       type(vector_t), intent(in) :: vector
       real(kind = real64), intent(out) :: value

--- a/modules/structs/dynamic/vector/submodules/Vector_real64_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_real64_t_push_back_methods.for
@@ -142,9 +142,7 @@ contains
       real(kind = real64), allocatable :: array(:)
 
       call backup  (vector, array)
-
-      vector % limit % idx = 2_int64 * vector % limit % idx !! doubles size
-
+      call double  (vector)
       call restore (vector, array, value)
 
       return

--- a/modules/structs/dynamic/vector/submodules/Vector_real64_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_real64_t_push_back_methods.for
@@ -135,6 +135,41 @@ contains
   end subroutine vector_real64_t_push_array
 
 
+  module pure subroutine vector_real64_t_push_n_copies (vector, n, value)
+      ! Synopsis: pushes `n' copies of value unto the back of vector.
+      type(vector_t), intent(inout), target :: vector
+      real(kind = real64), intent(in) :: value
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64) :: numel
+      integer(kind = int64) :: final
+
+
+      numel = n
+
+      associate (begin  => vector % begin % idx,  &
+               & avail  => vector % avail % idx,  &
+               & values => vector % array % values)
+
+          final = avail + numel - 1_int64
+
+          select type (values)
+              type is ( real(kind = real64) )
+                  values (avail:final) = value
+              class default
+                  ! caters inserting mixed-types
+                  error stop vector % state % errmsg
+          end select
+
+          vector % deref % it => vector % array % values(begin:final)
+          avail = avail + numel
+
+      end associate
+
+
+      return
+  end subroutine vector_real64_t_push_n_copies
+
+
   module subroutine vector_real64_t_grow (vector, value)
       ! Synopsis: Doubles the vector size.
       type(vector_t), intent(inout) :: vector

--- a/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
@@ -233,16 +233,30 @@ contains
 
               associate (values => from % array % values)
                   select type (values)
+
                       type is ( integer(kind = int32) )
+
+                          call allocator      (to, errmsg_i32)
                           to % state % errmsg(:) = errmsg_i32
+
                       type is ( integer(kind = int64) )
+
+                          call allocator      (to, errmsg_i64)
                           to % state % errmsg(:) = errmsg_i64
+
                       type is ( real(kind = real64) )
+
+                          call allocator      (to, errmsg_r64)
                           to % state % errmsg(:) = errmsg_r64
+
                       type is (vector_t)
+
+                          call allocator      (to, errmsg_vec)
                           to % state % errmsg(:) = errmsg_vec
+
                       class default
                           error stop errmsg
+
                   end select
               end associate
 

--- a/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
@@ -1,4 +1,3 @@
-!
 !   source: Vector_type_oblivious_methods.for
 !   author: misael-diaz
 !   date:   2021-06-28
@@ -174,12 +173,11 @@ contains
               ! Synopsis:
               ! Initializes (destination) fields from (source) vector while
               ! leaving the `avail' field and the `iterator' to be set by
-              ! the generic `push' method.
+              ! the generic `push' method at an appropriate time.
 
-              call allocator (to)
+              call instantiate (to)
 
               to % begin % idx = from % begin % idx
-              to % avail % idx = 0_int64
               to % limit % idx = from % limit % idx
               to % deref % idx = from % deref % idx
 

--- a/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
@@ -274,7 +274,7 @@ contains
 
 
           subroutine valid
-              ! validates iterators by destroying and re-associating them
+              ! validates iterators by re-associating them
 
               associate (begin => to % begin % idx, &
                        & avail => to % avail % idx, &
@@ -283,7 +283,6 @@ contains
                       type is (vector_t)
 
                           do i = begin, avail - 1_int64
-                              call allocator (array(i) % deref)
                               b = array(i) % begin % idx
                               e = array(i) % avail % idx - 1_int64
                               associate (vals => array(i) % array % values)

--- a/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
@@ -314,6 +314,10 @@ contains
       type(vector_t), intent(inout), target :: vector
       integer(kind = int64) :: i, b, e
 
+      if ( .not. allocated(vector % array) ) then
+          call instantiate (vector)             !! caters `empty' vectors
+      end if
+
       associate (begin => vector % begin % idx, &
                & avail => vector % avail % idx, &
                & ary => vector % array % values)
@@ -353,7 +357,7 @@ contains
                   vector % deref % it => vector % array % values(b:e)
 
               class default
-                  error stop 'validate iterators: unexpected error'
+                  vector % deref % it => null()
 
           end select
 

--- a/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_type_oblivious_methods.for
@@ -96,13 +96,11 @@ contains
           if ( allocated(vector % array) ) then
 
               if ( allocated(vector % array % values) ) then
-                  call deallocator (self % array)
                   call vector_vector_t_copy (self, vector)
               end if
 
           else
 
-              call deallocator (self % array)
               call instantiate (self)
 
           end if

--- a/modules/structs/dynamic/vector/submodules/Vector_utils.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_utils.for
@@ -521,6 +521,41 @@ contains
   end subroutine
 
 
+  pure subroutine double_vector_size (vector)
+      ! Synopsis:
+      ! Doubles the vector-size at most, complains if doing so would yield
+      ! an ill-formed object.
+      type(vector_t), intent(inout) :: vector
+      integer(kind = int64) :: limit            !! vector-size
+      integer(kind = int64) :: mask             !! bitmask
+      integer(kind = int32) :: msb              !! most significant bit
+      character(*), parameter :: errMSG = &     !! error message
+          & 'vector has reached its size limit'
+
+      limit = vector % limit % idx
+
+      mask = 0_int64
+      msb = imsb(limit) + 1
+      call illformed_check
+
+      limit = ibset(mask, msb)
+      vector % limit % idx = limit
+
+      return
+      contains
+
+          pure subroutine illformed_check
+              ! checks if doubling the size yields an ill-formed object
+              if ( msb == BITS_MAX_BIT ) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+  end subroutine double_vector_size
+
+
 !       module function to_string_int32 (i) result(str)
 !           integer(kind = int32), intent(in) :: i
 !           character(len = 64) :: str

--- a/modules/structs/dynamic/vector/submodules/Vector_utils.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_utils.for
@@ -62,52 +62,93 @@ contains
   module subroutine allocate_iter_t (i)
       type(iter_t), intent(inout), allocatable :: i
       integer(kind = int32) :: mstat
+      character(*), parameter :: errMSG = &
+          & "vector.allocate_iter_t: (de)allocation error"
 
-      mstat = 0
-      if ( .not. allocated(i) ) then
-          allocate (i, stat = mstat)
-      end if
+      call dealloc
 
-      if (mstat /= 0) then
-          error stop "vector.allocate_iter_t: allocation error"
-      end if
+      allocate (i, stat = mstat)
+      if (mstat /= 0) error stop errMSG
 
       return
+      contains
+
+          subroutine dealloc
+
+              mstat = 0
+              if ( allocated(i) ) then
+                  deallocate (i, stat = mstat)
+              end if
+
+              if (mstat /= 0) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
   end subroutine
 
 
   module subroutine allocate_data_t (d)
       type(data_t), intent(inout), allocatable :: d
       integer(kind = int32) :: mstat
+      character(*), parameter :: errMSG = &
+          & "vector.allocate_data_t: (de)allocation error"
 
-      mstat = 0
-      if ( .not. allocated(d) ) then
-          allocate (d, stat = mstat)
-      end if
+      call dealloc
 
-      if (mstat /= 0) then
-          error stop "vector.allocate_data_t: allocation error"
-      end if
+      allocate (d, stat = mstat)
+      if (mstat /= 0) error stop errMSG
 
       return
-  end subroutine
+      contains
+
+          subroutine dealloc
+
+              mstat = 0
+              if ( allocated(d) ) then
+                  deallocate (d, stat = mstat)
+              end if
+
+              if (mstat /= 0) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+  end subroutine allocate_data_t
 
 
   module subroutine allocate_stat_t (s)
       type(stat_t), intent(inout), allocatable :: s
       integer(kind = int32) :: mstat
+      character(*), parameter :: errMSG = &
+          & "vector.allocate_stat_t: (de)allocation error"
 
-      mstat = 0
-      if ( .not. allocated(s) ) then
-          allocate (s, stat = mstat)
-      end if
+      call dealloc
 
-      if (mstat /= 0) then
-          error stop "vector.allocate_stat_t: allocation error"
-      end if
+      allocate (s, stat = mstat)
+      if (mstat /= 0) error stop errMSG
 
       return
-  end subroutine
+      contains
+
+          subroutine dealloc
+
+              mstat = 0
+              if ( allocated(s) ) then
+                  deallocate (s, stat = mstat)
+              end if
+
+              if (mstat /= 0) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+  end subroutine allocate_stat_t
 
 
   module subroutine vector_allocate_errmsg (vector, errMSG)
@@ -500,6 +541,17 @@ contains
 !
 !           return
 !       end function
+
+
+  module subroutine destructor_iter_t (i)
+      type(iter_t), intent(inout) :: i
+
+      if ( associated(i % it) ) then
+          i % it => null()
+      end if
+
+      return
+  end subroutine
 
 
   module subroutine destructor_stat_t (s)

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
@@ -28,6 +28,96 @@ implicit none
 contains
 
 
+  module function vector_vector_t_fillConstructor (n, value) result(vec)
+      ! Synopsis: Creates a vector having `n' copies of `value'.
+      type(vector_t), allocatable :: vec
+      type(vector_t), intent(in) :: value
+      integer(kind = int64), intent(in) :: n
+      class(*), pointer, contiguous :: iter(:) => null()
+      integer(kind = int32) :: mstat
+      integer(kind = int64) :: bounds(0:1)
+      integer(kind = int64) :: b, e, idx
+      character(*), parameter :: errMSG = &
+          & "vector(): the number of copies must be a positive integer"
+
+      call check                !! complains on invalid inputs
+      call alloc                !! allocates memory for vector
+      call instantiate (vec)    !! initializes the vector components
+      call tailor               !! tailors the vector to store `n' copies
+
+
+      ! pushes `n' copies of the value `value' unto vector
+      call push (vec, n, value)
+      call valid                !! validates iterators
+
+      vec % state % init = .true.
+
+      return
+      contains
+
+          subroutine check
+              ! complains on invalid input
+
+              if (n <= 0_int64) then
+                  error stop errMSG
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine alloc
+              ! allocates memory for a vector
+
+              allocate (vec, stat=mstat)
+              if (mstat /= 0) then
+                  error stop 'vector(): memory allocation error'
+              end if
+
+              return
+          end subroutine
+
+
+          subroutine tailor
+              ! tailors the vector size based on the number of copies
+
+              vec % limit % idx = n     !! sets the vector `limit' to fit
+              call double (vec)         !! and doubles it for convenience
+
+              bounds(0) = 0_int64
+              bounds(1) = vec % limit % idx
+              call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
+
+          subroutine valid
+              ! recreates iterators to validate them
+
+              iter => vec % deref % it
+              select type (iter)
+                  type is (vector_t)
+                      do idx = 1, n
+
+                          call allocator (iter(idx) % deref)
+                          b = iter(idx) % begin % idx
+                          e = iter(idx) % avail % idx - 1_int64
+                          associate (values => iter(idx) % array % values)
+                              iter(idx) % deref % it => values(b:e)
+                          end associate
+
+                      end do
+                  class default
+                      error stop 'vector(): unexpected error'
+              end select
+
+              return
+          end subroutine
+
+  end function vector_vector_t_fillConstructor
+
+
   module subroutine vector_vector_t_indexer (vector, idx, value)
       type(vector_t), intent(in) :: vector
       type(vector_t), intent(inout) :: value

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
@@ -93,14 +93,13 @@ contains
 
 
           subroutine valid
-              ! recreates iterators to validate them
+                  ! re-associates iterators to validate them
 
               iter => vec % deref % it
               select type (iter)
                   type is (vector_t)
                       do idx = 1, n
 
-                          call allocator (iter(idx) % deref)
                           b = iter(idx) % begin % idx
                           e = iter(idx) % avail % idx - 1_int64
                           associate (values => iter(idx) % array % values)

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
@@ -37,15 +37,18 @@ contains
       integer(kind = int64) :: bounds(0:1)
       character(*), parameter :: errMSG = &
           & "vector(): the number of copies must be a positive integer"
+      character(len=*), parameter :: name = 'dynamic::vector.error:'
+      character(len=*), parameter :: errmsg_vec = name // ' ' // &
+          & 'container of vectors'
+      character(len=*), parameter :: unimplmntd = name // ' ' // &
+          & 'unimplemented vector<T>'
 
       call check                !! complains on invalid inputs
       call alloc                !! allocates memory for vector
-      call instantiate (vec)    !! initializes the vector components
+      call init                 !! initializes the vector components
       call tailor               !! tailors the vector to store `n' copies
-
-
-      ! pushes `n' copies of the value `value' unto vector
-      call push (vec, n, value)
+      call error                !! sets the internal error message
+      call insert               !! pushes `n' copies of `value' unto vector
       call valid                !! validates iterators
 
       vec % state % init = .true.
@@ -76,6 +79,15 @@ contains
           end subroutine
 
 
+          subroutine init
+              ! provides initial values to the vector components
+
+              call instantiate (vec)
+
+              return
+          end subroutine
+
+
           subroutine tailor
               ! tailors the vector size based on the number of copies
 
@@ -85,6 +97,32 @@ contains
               bounds(0) = 0_int64
               bounds(1) = vec % limit % idx
               call allocator (bounds, vec % array % values, value)
+
+              return
+          end subroutine
+
+
+          subroutine error
+              ! defines the internal error message of vector
+
+              associate (values => vec % array % values)
+                  select type (values)
+                      type is (vector_t)
+                          call allocator      (vec, errmsg_vec)
+                          vec % state % errmsg(:) = errmsg_vec
+                      class default
+                          error stop unimplmntd
+                  end select
+              end associate
+
+              return
+          end subroutine error
+
+
+          subroutine insert
+              ! inserts values unto the back of vector
+
+              call push (vec, n, value)
 
               return
           end subroutine

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
@@ -33,10 +33,8 @@ contains
       type(vector_t), allocatable :: vec
       type(vector_t), intent(in) :: value
       integer(kind = int64), intent(in) :: n
-      class(*), pointer, contiguous :: iter(:) => null()
       integer(kind = int32) :: mstat
       integer(kind = int64) :: bounds(0:1)
-      integer(kind = int64) :: b, e, idx
       character(*), parameter :: errMSG = &
           & "vector(): the number of copies must be a positive integer"
 
@@ -93,23 +91,9 @@ contains
 
 
           subroutine valid
-                  ! re-associates iterators to validate them
+              ! re-associates iterators to validate them
 
-              iter => vec % deref % it
-              select type (iter)
-                  type is (vector_t)
-                      do idx = 1, n
-
-                          b = iter(idx) % begin % idx
-                          e = iter(idx) % avail % idx - 1_int64
-                          associate (values => iter(idx) % array % values)
-                              iter(idx) % deref % it => values(b:e)
-                          end associate
-
-                      end do
-                  class default
-                      error stop 'vector(): unexpected error'
-              end select
+              call vector_validate_iterator (vec)
 
               return
           end subroutine

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_implementations.for
@@ -50,6 +50,7 @@ contains
       call error                !! sets the internal error message
       call insert               !! pushes `n' copies of `value' unto vector
       call valid                !! validates iterators
+!     call debug
 
       vec % state % init = .true.
 
@@ -132,6 +133,26 @@ contains
               ! re-associates iterators to validate them
 
               call vector_validate_iterator (vec)
+
+              return
+          end subroutine
+
+
+          subroutine debug
+              ! prints the addresses of the internal array and iterator
+
+              class(*), pointer, contiguous :: iter(:) => null()
+              integer(kind = int64) :: i
+
+              iter => vec % deref % it
+              select type (iter)
+                  type is (vector_t)
+
+                      do i = 1_int64, n
+                          call iter(i) % addr()
+                      end do
+
+              end select
 
               return
           end subroutine

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_push_back_methods.for
@@ -135,6 +135,41 @@ contains
   end subroutine vector_vector_t_push_array
 
 
+  module subroutine vector_vector_t_push_n_copies (vector, n, value)
+      ! Synopsis: pushes `n' copies of value unto the back of vector.
+      type(vector_t), intent(inout), target :: vector
+      type(vector_t), intent(in) :: value
+      integer(kind = int64), intent(in) :: n
+      integer(kind = int64) :: numel
+      integer(kind = int64) :: final
+
+
+      numel = n
+
+      associate (begin  => vector % begin % idx,  &
+               & avail  => vector % avail % idx,  &
+               & values => vector % array % values)
+
+          final = avail + numel - 1_int64
+
+          select type (values)
+              type is (vector_t)
+                  values (avail:final) = value
+              class default
+                  ! caters inserting mixed-types
+                  error stop vector % state % errmsg
+          end select
+
+          vector % deref % it => vector % array % values(begin:final)
+          avail = avail + numel
+
+      end associate
+
+
+      return
+  end subroutine vector_vector_t_push_n_copies
+
+
   module subroutine vector_vector_t_grow (vector, value)
       ! Synopsis: Doubles the vector size.
       type(vector_t), intent(inout) :: vector

--- a/modules/structs/dynamic/vector/submodules/Vector_vector_t_push_back_methods.for
+++ b/modules/structs/dynamic/vector/submodules/Vector_vector_t_push_back_methods.for
@@ -142,9 +142,7 @@ contains
       type(vector_t), allocatable :: array(:)
 
       call backup  (vector, array)
-
-      vector % limit % idx = 2_int64 * vector % limit % idx !! doubles size
-
+      call double  (vector)
       call restore (vector, array, value)
 
       return

--- a/tests/modules/structs/dynamic/vector/test_vector.for
+++ b/tests/modules/structs/dynamic/vector/test_vector.for
@@ -44,11 +44,13 @@ module vector_class_tests
     contains
 
         subroutine test_vector_fill_constructor ()
+            type(vector_t), allocatable :: vector  !! `empty' vector
             type(vector_t), allocatable :: v_i32   !! vector <int32_t>
             type(vector_t), allocatable :: v_i64   !! vector <int64_t>
             type(vector_t), allocatable :: v_r64   !! vector <real64_t>
             type(vector_t), allocatable :: vofvec  !! vector of vectors
             type(vector_t), allocatable :: avofvec !! another vec of vecs
+            type(vector_t), allocatable :: yavofv  !! yet another v of vecs
             class(*), pointer, contiguous :: it(:) => null()
             class(*), pointer, contiguous :: iter(:) => null()
             integer(kind = int64), parameter :: numel = 64_int64
@@ -57,8 +59,10 @@ module vector_class_tests
             integer(kind = int32):: mstat
 
 
-            allocate (v_i32, v_i64, v_r64, vofvec, avofvec, stat=mstat)
+            allocate (vector, v_i32, v_i64, v_r64, vofvec, avofvec, &
+                    & yavofv, stat=mstat)
             if (mstat /= 0) error stop 'test.vector(): allocation error'
+
 
             ! constructs vectors having `numel' copies of `value'
             v_i32 = vector_t (numel, value)
@@ -168,8 +172,11 @@ module vector_class_tests
                 print *, 'pass'
             end if
 
+            vector = vector_t ()                !! `empty' vector <T>
+            yavofv = vector_t (numel, vector)   !! vector < vector<T> >
 
-            deallocate (v_i32, v_i64, v_r64, vofvec, avofvec)
+            deallocate (vector, v_i32, v_i64, v_r64, vofvec, avofvec, &
+                      & yavofv)
 
             return
         end subroutine

--- a/tests/modules/structs/dynamic/vector/test_vector.for
+++ b/tests/modules/structs/dynamic/vector/test_vector.for
@@ -260,10 +260,10 @@ module vector_class_tests
                 error stop "test::vector.array: allocation error"
             end if
 
-!! BUG      vector[(:)] = create () ! Iterators point to the same object !
+!! BUG      vector[(:)] = create ()     !! iterators point to invalid obj
             do i = 1_int64, 2_int64
                 ! instantiates array of vectors the right way
-                vector(i) = create ()
+                vector(i) = create ()   !! invokes ``assignment'' method
             end do
 
 

--- a/tests/modules/structs/dynamic/vector/test_vector.for
+++ b/tests/modules/structs/dynamic/vector/test_vector.for
@@ -54,7 +54,7 @@ module vector_class_tests
             class(*), pointer, contiguous :: it(:) => null()
             class(*), pointer, contiguous :: iter(:) => null()
             integer(kind = int64), parameter :: numel = 64_int64
-            integer(kind = int64):: i, j, k, diff(3), diffs(2)
+            integer(kind = int64):: i, j, k, diff(3), diffs(3)
             integer(kind = int32), parameter :: value = 64
             integer(kind = int32):: mstat
 
@@ -174,6 +174,43 @@ module vector_class_tests
 
             vector = vector_t ()                !! `empty' vector <T>
             yavofv = vector_t (numel, vector)   !! vector < vector<T> >
+
+            ! checks that the iterator of the `empty' vectors point to NULL
+            diffs(3) = 0_int64
+            iter => yavofv % deref % it
+            select type (iter)
+                type is (vector_t)
+                    do i = 1_int64, (numel - 1_int64)
+                        do j = i + 1_int64, numel
+
+                            associate (it_1 => iter(i) % deref % it, &
+                                     & it_2 => iter(j) % deref % it)
+
+                                if ( loc(it_1) == loc(it_2) ) then
+                                    if ( loc(it_1) /= 0_int64 ) then
+                                        ! increments if different from NULL
+                                        diffs(3) = diffs(3) + 1_int64
+                                    end if
+                                end if
+
+                            end associate
+
+                        end do
+                    end do
+                class default
+                    error stop 'test.vector(): unexpected error'
+            end select
+
+
+            write (*, '(A)', advance='no') '[02] test-vector.construct(): '
+            if ( yavofv % size () /= numel ) then
+                print *, 'FAIL'
+            else if (diffs(3) /= 0_int64) then
+                print *, 'FAIL'
+            else
+                print *, 'pass'
+            end if
+
 
             deallocate (vector, v_i32, v_i64, v_r64, vofvec, avofvec, &
                       & yavofv)

--- a/tests/modules/structs/dynamic/vector/test_vector.for
+++ b/tests/modules/structs/dynamic/vector/test_vector.for
@@ -30,6 +30,7 @@ module vector_class_tests
     implicit none
     integer(kind = int64), parameter :: max_vector_size = 1048576_int64
     private
+    public :: test_vector_fill_constructor
     public :: test_vector_get
     public :: test_vector_push_back
     public :: test_vector_copy
@@ -41,6 +42,46 @@ module vector_class_tests
     public :: test_vector_up_array_vector_t
     public :: test_vector_mold_vector_t
     contains
+
+        subroutine test_vector_fill_constructor ()
+            type(vector_t), allocatable :: vector
+            class(*), pointer, contiguous :: it(:) => null()
+            integer(kind = int64), parameter :: numel = 64_int64
+            integer(kind = int64):: diff
+            integer(kind = int32), parameter :: value = 64
+            integer(kind = int32):: mstat
+
+
+            allocate (vector, stat=mstat)
+            if (mstat /= 0) error stop 'test.vector(): allocation error'
+
+            ! constructs a vector having `numel' copies of `value'
+            vector = vector_t (numel, value)
+            it => vector % deref % it
+
+
+            select type (it)
+                type is ( integer(kind = int32) )
+                    diff = int(sum(it), kind = int64) - numel * value
+                class default
+                    error stop 'test.vector(): unexpected error'
+            end select
+
+
+            write (*, '(A)', advance='no') '[00] test-vector.construct(): '
+            if ( vector % size () /= numel ) then
+                print *, 'FAIL'
+            else if (diff /= 0_int64) then
+                print *, 'FAIL'
+            else
+                print *, 'pass'
+            end if
+
+
+            deallocate (vector)
+
+            return
+        end subroutine
 
 
         subroutine test_vector_push_back ()
@@ -741,6 +782,7 @@ end module
 
 
 program test_vector_class
+    use vector_class_tests, only: construct => test_vector_fill_constructor
     use vector_class_tests, only: get => test_vector_get
     use vector_class_tests, only: push_back => test_vector_push_back
     use vector_class_tests, only: copy => test_vector_copy
@@ -756,6 +798,7 @@ program test_vector_class
     implicit none
 
 
+    call construct ()
     call push_back ()
     call copy ()
     call get ()


### PR DESCRIPTION
The implemented constructor is based on the c++ standard vector [fill](https://www.cplusplus.com/reference/vector/vector/vector/) constructor. The constructor creates a vector filled with `n` copies of a given type. There are no templates in FORTRAN so the type has to be one of the types supported by the vector class.

closes #84
closes #87
closes #88 
closes #89 
closes #90 
closes #91

The changes also provide some of the features needed to push an array into a vector ( issue #63 ).