### PR TITLE
checks the C-FORTRAN interoperability [FORTRAN]

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,8 +18,11 @@ include make-inc
 
 all: $(TESTS)
 
-$(TEST_BIN): $(OBJECTS)
-	$(CC) $(CCOPT) $(OBJECTS) -o $(TEST_BIN) $(LIBS)
+$(MAIN_BIN): $(UTIL_OBJ) $(SPHERE_OBJ) $(MAIN_OBJ)
+	$(FC) $(FCOPT) $(UTIL_OBJ) $(SPHERE_OBJ) $(MAIN_OBJ) -o $(MAIN_BIN)
+
+$(TEST_BIN): $(UTIL_OBJ) $(SPHERE_OBJ) $(TEST_OBJ)
+	$(CC) $(CCOPT) $(UTIL_OBJ) $(SPHERE_OBJ) $(TEST_OBJ) -o $(TEST_BIN) $(LIBS)
 
 $(UTIL_OBJ): $(UTIL_SRC)
 	$(CC) $(CCOPT) -c $(UTIL_SRC) -o $(UTIL_OBJ)
@@ -29,6 +32,9 @@ $(SPHERE_OBJ): $(UTIL_OBJ) $(SPHERE_SRC)
 
 $(TEST_OBJ): $(UTIL_OBJ) $(SPHERE_OBJ) $(TEST_SRC)
 	$(CC) $(CCOPT) -c $(TEST_SRC) -o $(TEST_OBJ)
+
+$(MAIN_OBJ): $(UTIL_OBJ) $(SPHERE_OBJ) $(MAIN_SRC)
+	$(FC) $(FCOPT) -c $(MAIN_SRC) -o $(MAIN_OBJ)
 
 clean:
 	/bin/rm -rf *.o $(TESTS)

--- a/src/main.f
+++ b/src/main.f
@@ -1,0 +1,164 @@
+!   OpenBDS                                                     July 19, 2023
+!
+!   source: main.for
+!   author: @misael-diaz
+!
+!   Synopsis:
+!   Creates a system of non-interacting Brownian spheres, checks their
+!   initial values, and destroys them.
+!
+!   Copyright (C) 2023 Misael Diaz-Maldonado
+!
+!   This program is free software: you can redistribute it and/or modify
+!   it under the terms of the GNU General Public License as published by
+!   the Free Software Foundation, either version 3 of the License, or
+!   (at your option) any later version.
+!
+!   This program is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!   GNU General Public License for more details.
+!
+!   You should have received a copy of the GNU General Public License
+!   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!   References:
+!   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+!   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+!   [2] S Kim and S Karrila, Microhydrodynamics.
+!
+
+#include "system.h"
+
+module bds
+  use, intrinsic :: iso_c_binding, only: c_ptr
+  use, intrinsic :: iso_fortran_env, only: real64
+  implicit none
+  private
+  save
+
+  ! C and FORTRAN sphere types:
+
+  public :: csphere_t
+  public :: fsphere_t
+
+  ! memory handling functions:
+
+  public :: create
+  public :: destroy
+
+  ! type definitions:
+
+  type :: csphere_t     ! clang sphere type
+    type(c_ptr) :: x
+    type(c_ptr) :: y
+    type(c_ptr) :: z
+    type(c_ptr) :: f_x
+    type(c_ptr) :: f_y
+    type(c_ptr) :: f_z
+    type(c_ptr) :: id
+    type(c_ptr) :: data
+  end type
+
+  type :: fsphere_t     ! flang sphere type
+    real(kind = real64), pointer, contiguous :: x(:) => null()
+    real(kind = real64), pointer, contiguous :: y(:) => null()
+    real(kind = real64), pointer, contiguous :: z(:) => null()
+    real(kind = real64), pointer, contiguous :: f_x(:) => null()
+    real(kind = real64), pointer, contiguous :: f_y(:) => null()
+    real(kind = real64), pointer, contiguous :: f_z(:) => null()
+    real(kind = real64), pointer, contiguous :: id(:) => null()
+  end type
+
+  ! defines interfaces to memory handling functions:
+
+  interface
+    function create () bind(c) result(sph)
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      type(c_ptr) :: sph
+    end function
+  end interface
+
+  interface
+    function destroy (sph) bind(c) result(res)
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      type(c_ptr), value :: sph
+      type(c_ptr) :: res
+    end function
+  end interface
+
+end module bds
+
+
+program main
+  use, intrinsic :: iso_c_binding, only: c_ptr
+  use, intrinsic :: iso_c_binding, only: c_f_pointer
+  use, intrinsic :: iso_fortran_env, only: real64
+  use, intrinsic :: iso_fortran_env, only: int64
+  use :: bds, only: csphere_t
+  use :: bds, only: fsphere_t
+  use :: bds, only: destroy
+  use :: bds, only: create
+  implicit none
+
+  integer(kind = int64), parameter :: numel = NUM_SPHERES
+
+  type(c_ptr) :: sph                    ! C pointer to the data of the spheres
+  type(csphere_t), pointer :: p_spheres ! FORTRAN pointer for binding to the C pointer
+  type(fsphere_t) :: spheres            ! with this we get access to the data from FORTRAN
+
+  real(kind = real64) :: f              ! accumulator for floating-point numbers
+  integer(kind = int64) :: num          ! accumulator for integral numbers
+  integer(kind = int64) :: i            ! counter (or index)
+
+  sph = create()
+
+  call c_f_pointer(sph, p_spheres)
+  call c_f_pointer(p_spheres % x, spheres % x, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % y, spheres % y, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % z, spheres % z, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % f_x, spheres % f_x, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % f_y, spheres % f_y, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % f_z, spheres % f_z, [NUM_SPHERES])
+  call c_f_pointer(p_spheres % id, spheres % id, [NUM_SPHERES])
+
+  ! checks the data (in an aggregate sense) against the expected values:
+
+  num = 0_int64
+  do i = 1, numel
+    num = num + int(spheres % id(i), kind=int64)
+  end do
+
+  write (*, '(A)', advance='no') 'test[0]: '
+  if (num /= NUM_SPHERES * (NUM_SPHERES - 1) / 2) then
+    print '(A)', 'FAIL'
+  else
+    print '(A)', 'PASS'
+  end if
+
+  f = 0.0_real64
+  do i = 1, numel
+    f = f + spheres % f_x(i)**2 + spheres % f_y(i)**2 + spheres % f_z(i)**2
+  end do
+
+  write (*, '(A)', advance='no') 'test[1]: '
+  if (f /= 0.0_real64) then
+    print '(A)', 'FAIL'
+  else
+    print '(A)', 'PASS'
+  end if
+
+  do i = 1, numel
+    f = f + spheres % x(i)**2 + spheres % y(i)**2 + spheres % z(i)**2
+  end do
+
+  write (*, '(A)', advance='no') 'test[2]: '
+  if (f /= 0.0_real64) then
+    print '(A)', 'FAIL'
+  else
+    print '(A)', 'PASS'
+  end if
+
+  sph = destroy(sph)
+
+end program main

--- a/src/make-inc
+++ b/src/make-inc
@@ -13,10 +13,15 @@
 # (at your option) any later version.
 #
 
+# FORTRAN compiler
+FC = gfortran
+
 # clang compiler
 CC = gcc
 
-# options
+FCOPT = -g -Wall -Wextra -O0 -cpp -ffree-form
+
+# clang options
 CCOPT = -O2 -ftree-vectorize -fopt-info-optimized=opts.log
 CCOPT = -g -Wall -Wextra -O0
 
@@ -24,17 +29,19 @@ CCOPT = -g -Wall -Wextra -O0
 LIBS = -lm
 
 # sources
+MAIN_SRC = main.f
 TEST_SRC = test.c
 UTIL_SRC = util.c
 SPHERE_SRC = sphere.c
 
 # objects
+MAIN_OBJ = main.o
 TEST_OBJ = test.o
 UTIL_OBJ = util.o
 SPHERE_OBJ = sphere.o
-OBJECTS = $(TEST_OBJ) $(UTIL_OBJ) $(SPHERE_OBJ)
 
 # binaries
 TEST_BIN = test.bin
+MAIN_BIN = main.bin
 
-TESTS = $(TEST_BIN)
+TESTS = $(MAIN_BIN) $(TEST_BIN)


### PR DESCRIPTION
COMMENTS:
Checks the C-FORTRAN interoperability

The idea is to bind the allocated memory in C to FORTRAN, as we were able to demonstrate in this commit.

We have checked that the data is consistent with the expectations.

Valgrind reports no memory issues.