### PR TITLE
applies naming convention [FORTRAN]

### DIFF
--- a/src/main.f
+++ b/src/main.f
@@ -38,9 +38,13 @@ module random
 
   public :: rand
 
+  interface rand
+    module procedure prng
+  end interface
+
   contains
 
-    subroutine rand (x)
+    subroutine prng (x)
       ! Implements Box-Muller's method, yields a Gaussian pseudo-random number.
       real(kind = real64), intent(out) :: x
       real(kind = real64) :: x1
@@ -70,7 +74,7 @@ module random
       x = x1
 
       return
-    end subroutine rand
+    end subroutine prng
 
 end module random
 
@@ -149,9 +153,17 @@ module tests
   public :: test_init
   public :: test_rand
 
+  interface test_init
+    module procedure initialization
+  end interface
+
+  interface test_rand
+    module procedure prng
+  end interface
+
   contains
 
-    subroutine test_init ()
+    subroutine initialization ()
       implicit none
 
       integer(kind = int64), parameter :: numel = NUM_SPHERES
@@ -218,9 +230,9 @@ module tests
       sph = destroy(sph)
 
       return
-    end subroutine test_init
+    end subroutine initialization
 
-    subroutine test_rand ()
+    subroutine prng ()
       ! checks the statistics of the Gaussian pseudo-random numbers
 
       real(kind = real64) :: x
@@ -243,7 +255,7 @@ module tests
       print *, 'std (should be close to one):  ', std
 
       return
-    end subroutine test_rand
+    end subroutine prng
 
 end module tests
 

--- a/src/main.f
+++ b/src/main.f
@@ -36,9 +36,9 @@ module random
   implicit none
   private
 
-  public :: rand
+  public :: random_prng
 
-  interface rand
+  interface random_prng
     module procedure prng
   end interface
 
@@ -142,7 +142,7 @@ module tests
   use, intrinsic :: iso_c_binding, only: c_f_pointer
   use, intrinsic :: iso_fortran_env, only: real64
   use, intrinsic :: iso_fortran_env, only: int64
-  use :: random, only: rand
+  use :: random, only: random_prng
   use :: bds, only: csphere_t
   use :: bds, only: fsphere_t
   use :: bds, only: destroy
@@ -243,7 +243,7 @@ module tests
       avg = 0.0_real64
       std = 0.0_real64
       do i = 1, NUM_SPHERES
-        call rand(x)
+        call random_prng(x)
         avg = avg + x
         std = std + x**2
       end do

--- a/src/main.f
+++ b/src/main.f
@@ -137,7 +137,7 @@ module bds
 
 end module bds
 
-module tests
+module test
   use, intrinsic :: iso_c_binding, only: c_ptr
   use, intrinsic :: iso_c_binding, only: c_f_pointer
   use, intrinsic :: iso_fortran_env, only: real64
@@ -257,11 +257,11 @@ module tests
       return
     end subroutine prng
 
-end module tests
+end module test
 
 program main
-  use :: tests, only: test_init
-  use :: tests, only: test_rand
+  use :: test, only: test_init
+  use :: test, only: test_rand
   implicit none
 
   call test_init()


### PR DESCRIPTION
adds the module name to the names of the methods for convenience