### PR TITLE
adds initial BDS code for spheres [FORTRAN]

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -2,6 +2,8 @@
 #define GUARD_OPENBDS_SYSTEM_H
 
 #define NUM_SPHERES 256
+#define NUM_STEPS 65536
+#define TIME_STEP 1.52587890625e-05
 
 #endif
 


### PR DESCRIPTION
COMMENTS:
adds initial Brownian Dynamics Simulator BDS code for spheres

the system is unbounded and the spheres do not interact with one another

all the spheres start at the origin of the system

valgrind reports no memory leaks