### PR TITLE
adds MSD computation [FORTRAN] [Python]

### DIFF
--- a/src/msd.py
+++ b/src/msd.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+OpenBDS                                             July 20, 2023
+
+source: msd.py
+author: @misael-diaz
+
+Synopsis:
+Plots the time evolution of the Mean Squared Displacement MSD.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] R Johansson, Numerical Python: Scientific Computing and Data
+    Science Applications with NumPy, SciPy, and Matplotlib, 2nd edition
+"""
+
+from numpy import loadtxt
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+
+t, msd = loadtxt('msd.txt').transpose()
+
+plt.close('all')
+plt.ion()
+fig, ax = plt.subplots()
+ax.loglog(t, 2 * t, linestyle='--', color='black', label='theory')
+ax.loglog(t, msd, linestyle='-', color='red', label='bds')
+ax.set_title('Mean Squared Displacement MSD of Brownian Spheres')
+ax.set_xlabel('time')
+ax.set_ylabel('MSD')
+ax.legend()

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -13,6 +13,10 @@ sphere_t* create ()
   size_t const size_f_x = SIZE;
   size_t const size_f_y = SIZE;
   size_t const size_f_z = SIZE;
+  size_t const size_t_x = SIZE;
+  size_t const size_t_y = SIZE;
+  size_t const size_t_z = SIZE;
+  size_t const size_list = SIZE;
   size_t const size_id = SIZE;
   size_t const size_data = size_x +
 			     size_y +
@@ -20,6 +24,10 @@ sphere_t* create ()
 			     size_f_x +
 			     size_f_y +
 			     size_f_z +
+			     size_t_x +
+			     size_t_y +
+			     size_t_z +
+			     size_list +
 			     size_id;
 
   size_t const bytes = size_data * sizeof(double);
@@ -48,7 +56,11 @@ sphere_t* create ()
   spheres -> f_x = spheres -> z + size_z;
   spheres -> f_y = spheres -> f_x + size_f_x;
   spheres -> f_z = spheres -> f_y + size_f_y;
-  spheres -> id = spheres -> f_z + size_f_z;
+  spheres -> t_x = spheres -> f_z + size_f_z;
+  spheres -> t_y = spheres -> t_x + size_t_x;
+  spheres -> t_z = spheres -> t_y + size_t_y;
+  spheres -> list = spheres -> t_z + size_t_z;
+  spheres -> id = spheres -> list + size_list;
 
   double* x = spheres -> x;
   double* y = spheres -> y;
@@ -56,6 +68,10 @@ sphere_t* create ()
   double* f_x = spheres -> f_x;
   double* f_y = spheres -> f_y;
   double* f_z = spheres -> f_z;
+  double* t_x = spheres -> t_x;
+  double* t_y = spheres -> t_y;
+  double* t_z = spheres -> t_z;
+  double* list = spheres -> list;
   double* id = spheres -> id;
 
   zeros(size_x, x);
@@ -64,6 +80,10 @@ sphere_t* create ()
   zeros(size_f_x, f_x);
   zeros(size_f_y, f_y);
   zeros(size_f_z, f_z);
+  zeros(size_t_x, t_x);
+  zeros(size_t_y, t_y);
+  zeros(size_t_z, t_z);
+  zeros(size_list, list);
   iota(size_id, id);
 
   return spheres;

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -11,6 +11,12 @@ typedef struct
   double* f_x;
   double* f_y;
   double* f_z;
+  // torque:
+  double* t_x;
+  double* t_y;
+  double* t_z;
+  // neighbor-list
+  double* list;
   // identifier:
   double* id;
   // container (this is what we allocate on the heap memory, the rest are just pointers)

--- a/src/system.h
+++ b/src/system.h
@@ -2,7 +2,7 @@
 #define GUARD_OPENBDS_SYSTEM_H
 
 #define NUM_SPHERES 256
-#define NUM_STEPS 65536
+#define NUM_STEPS 1048576
 #define TIME_STEP 1.52587890625e-05
 
 #endif


### PR DESCRIPTION
COMMENTS:
The python plot of the MSD (of non-interacting spheres) shows that it has excellent agreement with its theoretical counterpart.

The BDS code passes the existing tests.

Uses the (added) torque and neighbor-list arrays as temporaries.

Valgrind reports no memory issues.