### PR TITLE
updates init test code [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -1,8 +1,9 @@
 #include <stdio.h>
 #include "sphere.h"
+#include "system.h"
 
 // defines the system size, or equivalently, the number of spheres
-#define SIZE ( (size_t) 256 )
+#define SIZE ( (size_t) NUM_SPHERES )
 
 int main ()
 {


### PR DESCRIPTION
COMMENTS:
uses the number of spheres NUM_SPHERES MACRO in system header file instead of the previous hardcoded MACRO SIZE for consistency.