### PR TITLE
bitmasks particles by to their positions [clang]

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -4,6 +4,8 @@
 #define NUM_SPHERES 256
 #define NUM_STEPS 1048576
 #define TIME_STEP 1.52587890625e-05
+#define LIMIT 64.0
+#define LENGTH (2.0 * LIMIT)
 
 #endif
 

--- a/src/util.h
+++ b/src/util.h
@@ -8,4 +8,6 @@ bool sign (double const x);
 void zeros (size_t const size, double* x);
 void iota (size_t const size, double* x);
 
+void mask_partition (size_t const size, const double* restrict x, double* restrict mask);
+
 #endif


### PR DESCRIPTION
COMMENTS:
Bitmasking is useful for optimizing the application of periodic boundary conditions.

Granted, the application of the periodic boundary conditions is far from being the bottleneck of the application but whatever that can be done to speed up the code is worth my time, especially if it is going to be called often as in this case.

In theory we could have simply use the MACRO signbit() to obtain the same effect, and I would have done so if it weren't because the GCC compiler usually does not vectorize loops with calls to the math library unless unsafe math is enabled. For this reason I implemented a signbit() method for double precision (floating-point numbers) that can be vectorized by GCC.

What I have done so far is to partition the system into left and right partitions. The left partition contains the particles whose coordinates are negative, the converse is true for the right partition. Depending on their position we would have to either add or subtract the system length to the particles outside the system limits. This is the rationale for partitioning the system this way.

You could do the same by nesting suitable if-conditionals in a loop but it might not get vectorized by your favorite compiler. In my case GCC does not do so I had to use bitmasking to write a code that essentially does the same but that GCC can vectorize.

The implementation passes the test successfully.