### PR TITLE
tests application of periodic conditions [clang]

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -9,5 +9,10 @@ void zeros (size_t const size, double* x);
 void iota (size_t const size, double* x);
 
 void mask_partition (size_t const size, const double* restrict x, double* restrict mask);
+void mask_unlimited (size_t const size,
+		     const double* restrict x,
+		     const double* restrict mask,
+		     double* restrict temp,
+		     double* restrict bitmask);
 
 #endif


### PR DESCRIPTION
COMMENTS:
Uses bitwise operations to write code that GCC can vectorize.

Prescaling is used to make sure that abs(x) = [0, 2.0), where `x' represents either the `x', `y', or `z' axis coordinates of the particles, for the implementation of the algorithm that applies the periodic boundary conditions expects this scaling.

If it so happens that after prescaling abs(x) > 2 that could mean that the time-step of the simulation is inappropriate. For example, in such a bad situation this means that a pair (or more) particles have overlapped and as a consequence of this the force on the particles is so large that they will travel a distance larger than the dimensions of the system. The particle will go unnoticed and stay isolated from the rest of the particles until the end of the simulation. Even if the algorithm were to notice such scenario it would not make sense to bring the particles back to the system. It would be more sensible to inform the user and halt the simulation.

code passes the new test

valgrind reports no memory issues