### PR TITLE
stores IDs in 64-bit integer [clang] [FORTRAN]

### DIFF
--- a/src/main.f
+++ b/src/main.f
@@ -219,7 +219,7 @@ module bds
     real(kind = real64), pointer, contiguous :: t_y(:) => null()
     real(kind = real64), pointer, contiguous :: t_z(:) => null()
     real(kind = real64), pointer, contiguous :: list(:) => null()
-    real(kind = real64), pointer, contiguous :: id(:) => null()
+    integer(kind = int64), pointer, contiguous :: id(:) => null()
   end type
 
   ! defines interfaces to memory handling functions:
@@ -462,11 +462,7 @@ module test
 
       ! checks the data (in an aggregate sense) against the expected values:
 
-      num = 0_int64
-      do i = 1, numel
-        num = num + int(spheres % id(i), kind=int64)
-      end do
-
+      num = sum(spheres % id)
       write (*, '(A)', advance='no') 'test[0]: '
       if (num /= NUM_SPHERES * (NUM_SPHERES - 1) / 2) then
         print '(A)', 'FAIL'

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -84,7 +84,7 @@ sphere_t* create ()
   double* t_y = spheres -> t_y;
   double* t_z = spheres -> t_z;
   double* list = spheres -> list;
-  double* id = spheres -> id;
+  int64_t* id = spheres -> id;
 
   zeros(size_x, x);
   zeros(size_y, y);

--- a/src/sphere.h
+++ b/src/sphere.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_OPENBDS_SPHERE_H
 #define GUARD_OPENBDS_SPHERE_H
 
+#include <stdint.h>
+
 typedef struct
 {
   // position subject to periodic boundaries:
@@ -22,7 +24,7 @@ typedef struct
   // neighbor-list
   double* list;
   // identifier:
-  double* id;
+  int64_t* id;
   // container (this is what we allocate on the heap memory, the rest are just pointers)
   double* data;
 } sphere_t;

--- a/src/test.c
+++ b/src/test.c
@@ -35,10 +35,10 @@ void test_init ()
   sphere_t* spheres = create();
 
   size_t const size = SIZE;
-  const double* id = spheres -> id;
+  const int64_t* id = spheres -> id;
   for (size_t i = 0; i != size; ++i)
   {
-    printf("id: %.0f \n", id[i]);
+    printf("id: %ld \n", id[i]);
   }
 
   double f = 0;

--- a/src/util.c
+++ b/src/util.c
@@ -59,12 +59,11 @@ void zeros (size_t const size, double* x)
 }
 
 
-void iota (size_t const size, double* x)
+void iota (size_t const size, int64_t* x)
 {
   for (size_t i = 0; i != size; ++i)
   {
-    double const id = i;
-    x[i] = id;
+    x[i] = i;
   }
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -6,7 +6,7 @@
 
 bool sign (double const x);
 void zeros (size_t const size, double* x);
-void iota (size_t const size, double* x);
+void iota (size_t const size, int64_t* x);
 
 void mask_partition (size_t const size, const double* restrict x, double* restrict mask);
 void mask_unlimited (size_t const size,


### PR DESCRIPTION
COMMENTS:
Stores the particle IDs in a signed 64-bit integer for interoperability with FORTRAN. Note that the size (number of bytes) used for the size_t depends on the implementation so my only option was to use an integer of 64-bits since all the fields of the sphere_t are 64-bits by design (and I want to keep it that way for simplicity).

This change is necessary for it is unusual to use doubles for addressing arrays as will be done with the list of neighbors. I was aware of this from the beginning but decided to do this change just before working on the neighbor lists.

the code passes the existing tests

valgrind reports no memory issues