### PR TITLE
adds initial neighbor-list code [clang] [FORTRAN]

### DIFF
--- a/src/sphere.c
+++ b/src/sphere.c
@@ -9,6 +9,18 @@ sphere_t* create ()
 {
   // sane checks:
 
+  if (NUM_SPHERES == 0x7fffffffffffffff)
+  {
+    printf("create(): reserved value\n");
+    return NULL;
+  }
+
+  if (NUM_SPHERES % 2)
+  {
+    printf("create(): number of spheres must be even\n");
+    return NULL;
+  }
+
   size_t const len = LENGTH;
   // defines the number of spheres that fit (at contact) along any dimension (x, y, or z)
   size_t const count = (len / 2);

--- a/src/system.h
+++ b/src/system.h
@@ -6,6 +6,9 @@
 #define TIME_STEP 1.52587890625e-05
 #define LIMIT 8.0
 #define LENGTH (2.0 * LIMIT)
+#define RADIUS 1.0
+#define CONTACT (2.0 * RADIUS)
+#define RANGE ( (1.5 * CONTACT) * (1.5 * CONTACT) )
 
 #endif
 

--- a/src/util.h
+++ b/src/util.h
@@ -25,4 +25,9 @@ void pbc (double* restrict x,
 int64_t overlaps (const double* restrict x,
 		  const double* restrict y,
 		  const double* restrict z);
+
+void list(int64_t* restrict list,
+	  const double* restrict x,
+	  const double* restrict y,
+	  const double* restrict z);
 #endif


### PR DESCRIPTION
COMMENTS:
The BDS code passes all existing and new tests.

On purpose all particles are in contact with one another to test the implementation of the algorithm that generates the neighbor list.

This version does not take into account the periodicity of the system; nevertheless, it is correct to use it for dense suspensions where all the particles interact with one another (or form a single cluster sort of speak). Of course, the list won't be of any help other than to check that indeed all particles interact with one another.

Periodicity considerations shall be added later.

Valgrind reports no memory issues.

MACROS:

CONTACT is the contact distance which is two for unit spheres.

RANGE is the interaction range of the particles, and we use its squared value to avoid having to compute the squared root in the code for speed.

SANE CHECKS:

We have limited the maximum number of particles due to the use of negative numbers to store the ID of the head (or root) of the neighbor-list. Note that in the code we add `one' to the `id' so that if `id' is already the maximum (signed) 64-bit integer the operation would overflow, thereby breaking the logic. Nevertheless, I do not think that anyone would attempt a simulation of that scale in a serial code.