### PR TITLE
vectorizes interparticle distance computation [clang]

### DIFF
--- a/src/main.f
+++ b/src/main.f
@@ -500,10 +500,11 @@ module test
   end interface
 
   interface
-    subroutine c_list (list, x, y, z) bind(c, name = 'list')
+    subroutine c_list (list, dist, x, y, z) bind(c, name = 'list')
       use, intrinsic :: iso_c_binding, only: c_double
       use, intrinsic :: iso_c_binding, only: c_int64_t
       integer(kind = c_int64_t), dimension(NUM_SPHERES), intent(out) :: list
+      real(kind = c_double), dimension(NUM_SPHERES), intent(out) :: dist
       real(kind = c_double), dimension(NUM_SPHERES), intent(in) :: x
       real(kind = c_double), dimension(NUM_SPHERES), intent(in) :: y
       real(kind = c_double), dimension(NUM_SPHERES), intent(in) :: z
@@ -551,6 +552,7 @@ module test
       real(kind = real64), pointer, contiguous :: x(:) => null()
       real(kind = real64), pointer, contiguous :: y(:) => null()
       real(kind = real64), pointer, contiguous :: z(:) => null()
+      real(kind = real64), pointer, contiguous :: dist(:) => null()
       integer(kind = int64), pointer, contiguous :: list(:) => null()
 
       real(kind = real64) :: f              ! accumulator for floating-point numbers
@@ -577,6 +579,7 @@ module test
       call c_f_pointer(ptr_c_spheres % t_x, spheres % t_x, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % t_y, spheres % t_y, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % t_z, spheres % t_z, [NUM_SPHERES])
+      call c_f_pointer(ptr_c_spheres % tmp, spheres % tmp, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % list, spheres % list, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % id, spheres % id, [NUM_SPHERES])
 
@@ -674,9 +677,10 @@ module test
         print '(A)', 'PASS'
       end if
 
+      dist => spheres % tmp
       list => spheres % list
 
-      call c_list(list, x, y, z)
+      call c_list(list, dist, x, y, z)
 
       ! checks that all particles are interacting with one another, in such case the last
       ! particle is the tail of the list and its stored value should be -1 to indicate

--- a/src/util.c
+++ b/src/util.c
@@ -391,16 +391,7 @@ void list(int64_t* restrict list,
 
   for (size_t i = 0; i != NUM_SPHERES; ++i)
   {
-    for (size_t j = 0; j != i; ++j)
-    {
-      bool const linked = link(i, j, list, x, y, z);
-      if (linked)
-      {
-	break;
-      }
-    }
-
-    for (size_t j = (i + 1); j != NUM_SPHERES; ++j)
+    for (size_t j = 0; j != NUM_SPHERES; ++j)
     {
       bool const linked = link(i, j, list, x, y, z);
       if (linked)

--- a/src/util.c
+++ b/src/util.c
@@ -333,9 +333,7 @@ static int64_t tail (const int64_t* list, int64_t const i)
 static bool link (int64_t const i,
 		  int64_t const j,
 		  int64_t* restrict list,
-		  const double* restrict x,
-		  const double* restrict y,
-		  const double* restrict z)
+		  double const d)
 {
   int64_t const root_i = head(list, i);
   int64_t const root_j = head(list, j);
@@ -348,10 +346,6 @@ static bool link (int64_t const i,
   // checks if the particles interact with one another:
 
   bool linked = false;
-  double const d_x = (x[i] - x[j]);
-  double const d_y = (y[i] - y[j]);
-  double const d_z = (z[i] - z[j]);
-  double const d = d_x * d_x + d_y * d_y + d_z * d_z;
 
   if (d <= RANGE)
   {
@@ -380,6 +374,7 @@ static bool link (int64_t const i,
 
 // generates the neighbor-list
 void list(int64_t* restrict list,
+	  double* restrict d,
 	  const double* restrict x,
 	  const double* restrict y,
 	  const double* restrict z)
@@ -393,7 +388,15 @@ void list(int64_t* restrict list,
   {
     for (size_t j = 0; j != NUM_SPHERES; ++j)
     {
-      bool const linked = link(i, j, list, x, y, z);
+      d[j] = (x[i] - x[j]) * (x[i] - x[j]) +
+	     (y[i] - y[j]) * (y[i] - y[j]) +
+	     (z[i] - z[j]) * (z[i] - z[j]);
+    }
+
+    for (size_t j = 0; j != NUM_SPHERES; ++j)
+    {
+      double const dist = d[j];
+      bool const linked = link(i, j, list, dist);
       if (linked)
       {
 	break;

--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,7 @@ int64_t overlaps (const double* restrict x,
 		  const double* restrict z);
 
 void list(int64_t* restrict list,
+	  double* restrict d,
 	  const double* restrict x,
 	  const double* restrict y,
 	  const double* restrict z);


### PR DESCRIPTION
makes the code more concise
vectorizes distance computation though the time complexity remains the same
adds some comments for the next programmer (which could be myself)