### PR TITLE
aborts execution on runtime errors [FORTRAN]

### DIFF
--- a/src/main.f
+++ b/src/main.f
@@ -567,6 +567,11 @@ module test
       c_spheres = c_create()
 
       call c_f_pointer(c_spheres, ptr_c_spheres)
+
+      if ( .not. associated(ptr_c_spheres) ) then
+        return
+      end if
+
       call c_f_pointer(ptr_c_spheres % x, spheres % x, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % y, spheres % y, [NUM_SPHERES])
       call c_f_pointer(ptr_c_spheres % z, spheres % z, [NUM_SPHERES])


### PR DESCRIPTION
COMMENTS:
Aborts execution if for instance create() fails to allocate memory for sphere data; otherwise the could would segfault.

valgrind reports no memory issues (test not added)