### PR TITLE
initial list() implementation passes test [FORTRAN]

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -1,0 +1,33 @@
+#ifndef GUARD_OPENBDS_FMACROS_H
+#define GUARD_OPENBDS_FMACROS_H
+
+#define ARGS x, y, z,\
+	     r_x, r_y, r_z,\
+	     a_x, a_y, a_z,\
+	     f_x, f_y, f_z,\
+	     t_x, t_y, t_z,\
+	     tmp, list
+
+#endif
+
+/*
+
+OpenBDS								July 26, 2023
+
+source: fmacros.h
+author: @misael-diaz
+
+Synopsis:
+Defines some convenient FORTRAN MACROS.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/test.c
+++ b/src/test.c
@@ -20,6 +20,7 @@ void test_partition_masking();
 void test_unlimited_masking();
 void test_pbc();
 void test_list();
+void test_list2();
 void test_overlap();
 
 int main ()
@@ -29,6 +30,7 @@ int main ()
   test_unlimited_masking();
   test_pbc();
   test_list();
+  test_list2();
   test_overlap();
   return 0;
 }
@@ -660,6 +662,78 @@ void test_overlap ()
   {
     //printf("%+e %+e %+e\n", x[i], y[i], z[i]);
   }
+}
+
+
+void test_list2()
+{
+  const char fname[] = "positions.txt";
+  FILE* file = fopen(fname, "r");
+  if (file == NULL)
+  {
+    printf("IO ERROR with file: %s \n", fname);
+    return;
+  }
+
+  double data[4 * NUM_SPHERES];
+  double* x = data;
+  double* y = x + NUM_SPHERES;
+  double* z = y + NUM_SPHERES;
+  double* d = z + NUM_SPHERES;
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    int const numit = fscanf(file, "%lf %lf %lf \n", x, y, z);
+    if (numit != 3)
+    {
+      fclose(file);
+      // an error could happen if the number of spheres does not match the number of lines
+      printf("test_list2(): unexpected IO Error with %s \n", fname);
+      return;
+    }
+    ++x;
+    ++y;
+    ++z;
+  }
+
+  x = data;
+  y = x + NUM_SPHERES;
+  z = y + NUM_SPHERES;
+
+  // counts the number of out-of-range (or non-interacting) spheres:
+
+  size_t count = 0;
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    for (size_t j = 0; j != NUM_SPHERES; ++j)
+    {
+      d[j] = (x[i] - x[j]) * (x[i] - x[j]) +
+	     (y[i] - y[j]) * (y[i] - y[j]) +
+	     (z[i] - z[j]) * (z[i] - z[j]);
+    }
+
+    for (size_t j = 0; j != NUM_SPHERES; ++j)
+    {
+      double const dist = d[j];
+      if (dist > RANGE)
+      {
+	++count;
+      }
+    }
+  }
+
+  // `count' shouldn't be zero because the data (presumably) has more than one cluster:
+
+  printf("list-test[1]: ");
+  if (count == 0)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  fclose(file);
 }
 
 

--- a/src/util.c
+++ b/src/util.c
@@ -417,6 +417,31 @@ void list(int64_t* restrict list,
 }
 
 
+// counts the number of "clusters" in the system
+int64_t clusters (const int64_t* restrict list, double* restrict mask)
+{
+  typedef union
+  {
+    int64_t bin;
+    double data;
+  } alias_t;
+
+  alias_t* m = mask;
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    m[i].bin = ( (list[i] & MSBMASK) >> 63 );
+  }
+
+  int64_t clusters = 0;
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    clusters += m[i].bin;
+  }
+
+  return clusters;
+}
+
+
 // void mask_partition (size_t size, double* x, double* mask)
 //
 // Synopsis:

--- a/src/util.h
+++ b/src/util.h
@@ -31,4 +31,6 @@ void list(int64_t* restrict list,
 	  const double* restrict x,
 	  const double* restrict y,
 	  const double* restrict z);
+
+int64_t clusters (const int64_t* restrict list, double* restrict mask);
 #endif


### PR DESCRIPTION
COMMENTS:
demonstrates that when there is more than one cluster of particles some of the particles do not interact with one another, as one might expect.

the test consisted on exporting the particle positions to a plain text file when there is more than one cluster in the system and then checking (later) that there are indeed particles that do not interact with other particles.

have yet to consider the periodicity of the system

have added some convenient MACROS

BDS code passes new and existing tests

valgrind reports no memory issues