### PR TITLE
saves space usage of inrange() [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -1002,7 +1002,6 @@ void test_inrange ()
   double* z = y + NUM_SPHERES;	// z-position
   double* d = z + NUM_SPHERES;	// interparticle distance
   double* m = d + NUM_SPHERES;	// bitmask
-  double* t = m + NUM_SPHERES;	// temporary (placeholder for intermediate computations)
   for (size_t i = 0; i != NUM_SPHERES; ++i)
   {
     int const numit = fscanf(file, "%lf %lf %lf \n", x, y, z);

--- a/src/test.c
+++ b/src/test.c
@@ -1041,7 +1041,7 @@ void test_inrange ()
 
     // generates bitmasks for the pairs (ones if interacting, zeros otherwise):
 
-    inrange(d, t, m);
+    inrange(d, m);
 
     for (size_t j = 0; j != NUM_SPHERES; ++j)
     {

--- a/src/util.c
+++ b/src/util.c
@@ -68,19 +68,15 @@ static uint64_t mask_zero (uint64_t const x)
 
 
 // bitmasks interacting particles with ones, zeros otherwise
-void inrange (const double* restrict r, double* restrict mask, double* restrict bitmask)
+void inrange (const double* restrict r, double* restrict bitmask)
 {
-  alias_t* m = mask;
+  alias_t* b = bitmask;
   const alias_t* fp = r;
   for (size_t i = 0; i != NUM_SPHERES; ++i)
   {
-    m[i].bin = twos_complement( mask_zero(fp[i].bin) );
-  }
-
-  alias_t* b = bitmask;
-  for (size_t i = 0; i != NUM_SPHERES; ++i)
-  {
-    b[i].bin = ( m[i].bin & twos_complement( mask_inrange(fp[i].bin) ) );
+    uint64_t const z = twos_complement( mask_zero(fp[i].bin) );         // masks zeros
+    uint64_t const d = twos_complement( mask_inrange(fp[i].bin) );      // masks distant
+    b[i].bin = (z & d);
   }
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -432,7 +432,7 @@ void list(int64_t* restrict list,
     list[i] = -(i + 1);
   }
 
-  // generates the initial list of neighbors without considering the periodic boundaries:
+  // generates the initial list of neighbors while accounting for the periodic boundaries:
 
   for (size_t i = 0; i != NUM_SPHERES; ++i)
   {

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-void inrange (const double* restrict x, double* restrict mask, double* restrict bitmask);
+void inrange (const double* restrict x, double* restrict bitmask);
 
 bool sign (double const x);
 void zeros (double* x);


### PR DESCRIPTION
gcc can vectorize the loops in inrange()

code passes existing tests