### PR TITLE
relocates time-related MACROS

### DIFF
--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -8,6 +8,9 @@
 	     t_x, t_y, t_z,\
 	     tmp, list
 
+#define NUM_STEPS 1048576_int64
+#define TIME_STEP 1.52587890625e-05_real64
+
 #endif
 
 /*

--- a/src/main.f
+++ b/src/main.f
@@ -40,7 +40,7 @@ module param
   public
   save
 
-  real(kind = real64), parameter :: param_dt = real(TIME_STEP, kind = real64)
+  real(kind = real64), parameter :: param_dt = TIME_STEP
 
 end module param
 

--- a/src/system.h
+++ b/src/system.h
@@ -2,8 +2,6 @@
 #define GUARD_OPENBDS_SYSTEM_H
 
 #define NUM_SPHERES 256
-#define NUM_STEPS 1048576
-#define TIME_STEP 1.52587890625e-05
 #define LIMIT 8.0
 #define LENGTH (2.0 * LIMIT)
 #define RADIUS 1.0


### PR DESCRIPTION
COMMENTS:
Just to get rid of some implicit conversions and warnings issued by the GNU FORTRAN Compiler.

Want to make sure that there's no loss of precision in the time step (there's no more a 32 to 64-bit implicit conversion).

In the future it might be useful to define the number of steps as a 64-bit integer for long simulations.