### PR TITLE
adds shifted Lennard-Jones SLJ force [clang]

### DIFF
--- a/src/system.h
+++ b/src/system.h
@@ -6,8 +6,10 @@
 #define LENGTH (2.0 * LIMIT)
 #define RADIUS 1.0
 #define CONTACT (2.0 * RADIUS)
+#define CONTACT2 (CONTACT * CONTACT)
 #define RANGE (1.5 * CONTACT)
 #define RANGE2 (RANGE * RANGE)
+#define EPSILON 1.0
 
 #endif
 

--- a/src/test.c
+++ b/src/test.c
@@ -23,6 +23,7 @@ void test_list();
 void test_list2();
 void test_overlap();
 void test_inrange();
+void test_force();
 
 int main ()
 {
@@ -34,6 +35,7 @@ int main ()
   test_list2();
   test_overlap();
   test_inrange();
+  test_force();
   return 0;
 }
 
@@ -1080,6 +1082,49 @@ void test_inrange ()
   fclose(file);
 }
 
+
+// shows that the force is zero for non-interacting particles
+void test_force ()
+{
+  double d[NUM_SPHERES];
+  double r[NUM_SPHERES];
+  double f[NUM_SPHERES];
+  double mask[NUM_SPHERES];
+
+  zeros(d);
+  zeros(r);
+  zeros(f);
+  zeros(mask);
+
+  r[0] = 0.00;
+  r[1] = 1.00;
+  r[2] = 1.50;
+  r[3] = 2.00;
+  r[4] = 2.50;
+  r[5] = 2.75;
+  r[6] = 3.00;
+  r[7] = 4.00;
+  r[8] = 16.0;
+  r[9] = 64.0;
+
+  // we assume that the ith particle is located at the origin and that the jth particles
+  // are at a distance d = (d_i - d_j) from the ith particle (hence the negative sign)
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    d[i] = -r[i];
+  }
+
+  // note that we should not expect r to retain its values after calling force() because
+  // it is used as a placeholder for intermediate computations (the benefit of doing so
+  // is not evident at this point but it shall be later)
+  force(r, f, mask);
+
+  for (size_t i = 0; i != 16; ++i)
+  {
+    double const force = f[i] * d[i];
+    printf("r: %e f: %+e \n", -d[i], force);
+  }
+}
 
 /*
 

--- a/src/util.h
+++ b/src/util.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 void inrange (const double* restrict x, double* restrict bitmask);
+void force (double* restrict r, double* restrict force, double* restrict bitmask);
 
 bool sign (double const x);
 void zeros (double* x);


### PR DESCRIPTION
COMMENTS:
The force is zero if the distance is zero and if the distance is greater than the interaction range. This is so that we can use square for-loops to compute the net force on the particles. This is easier to parallelize with POSIX threads and OpenMP and it is also easier to vectorize than the triangular counterpart (yet with the same quadratic time complexity).

Note that only the repulsive contribution of the Lennard-Jones potential is used to compute the force. The force is shifted so that it vanishes exactly at the radius of cutoff (RANGE).

valgrind reports no memory issues