### PR TITLE
adds xorshift64() PRNG [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -24,6 +24,7 @@ void test_list2();
 void test_overlap();
 void test_inrange();
 void test_force();
+void test_xorshift64();
 
 int main ()
 {
@@ -36,6 +37,7 @@ int main ()
   test_overlap();
   test_inrange();
   test_force();
+  test_xorshift64();
   return 0;
 }
 
@@ -1125,6 +1127,36 @@ void test_force ()
     printf("r: %e f: %+e \n", -d[i], force);
   }
 }
+
+
+// checks only if xorshift64() returns values in the asymmetric range [0, 1)
+void test_xorshift64 ()
+{
+  size_t fails = 0;
+  int64_t state[] = { 0xffffffffffffffff };		// -1
+  uint64_t const period = 0xffffffffffffffff;		// 2^64 - 1
+  printf("xorshift64() period: %lu \n", period);
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    double const r = xorshift64(state);
+    //printf("r: %f \n", r);
+    if (r >= 1.0)
+    {
+      ++fails;
+    }
+  }
+
+  printf("xorshift64-test[0]: ");
+  if (fails != 0)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+}
+
 
 /*
 

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,22 @@ typedef union
 } alias_t;
 
 
+// implements Marsaglia's 64-bit xorshift, yields a uniformly distributed number in [0, 1)
+// uses a signed 64-bit integer for compatibility with FORTRAN
+double xorshift64 (int64_t* state)
+{
+  int64_t x = *state;
+  x ^= (x << 13);
+  x ^= (x >> 7);
+  x ^= (x << 17);
+  *state = x;
+
+  double const c = 1.0 / ( (int64_t) 0x8000000000000000 );
+  double const r = c * x;
+  return (0.5 * (r + 1.0) );
+}
+
+
 // returns the Most Significant Bit MSB (yields either zero or one)
 static uint64_t get_msb (uint64_t const x)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+double xorshift64 (int64_t* state);
+
 void inrange (const double* restrict x, double* restrict bitmask);
 void force (double* restrict r, double* restrict force, double* restrict bitmask);
 


### PR DESCRIPTION
COMMENTS:
Implements Marsaglia's 64-bit xorshift Pseudo Random Number Generator PRNG.

Uses signed 64-bit integers to implement the PRNG for interoperability with FORTRAN.

The PRNG yields uniformly distributed pseudo-random numbers in the asymmetric range [0, 1).