### PR TITLE
updates equilibration run [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -1853,12 +1853,21 @@ void test_force4 ()
       break;
     }
 
+    // checks if the positions are close to their final equilibrium positions:
+
+    force /= ( (3.0 * ( (double) NUM_SPHERES) ) );
+    force = sqrt(force);
+
+    double const tol = 9.5367431640625e-07;
+    if (force < tol)
+    {
+      break;
+    }
+
     // logs the average force along the axes on the console:
 
     if (step % 256 == 0)
     {
-      force /= ( (3.0 * ( (double) NUM_SPHERES) ) );
-      force = sqrt(force);
       printf("step: %lu force: %e \n", step, force);
     }
   }

--- a/src/test.c
+++ b/src/test.c
@@ -1873,6 +1873,12 @@ void test_force4 ()
     printf("PASS\n");
   }
 
+  if (failed)
+  {
+    spheres = destroy(spheres);
+    return;
+  }
+
   // exports the particle positions for post-processing:
 
   const char fname[] = "stable.txt";


### PR DESCRIPTION
does not write the particle positions to disk if the run fails (for it is necessary to decrease the time step further, especially for higher volume fractions)

halts the equilibration run if the average force is small enough (the particles have reached almost their equilibrium positions)