### PR TITLE
sets an upper bound on the max force [clang]

### DIFF
--- a/src/make-inc
+++ b/src/make-inc
@@ -30,7 +30,7 @@ FCOPT = -g -Wall -Wextra -Waliasing -Wsurprising -Warray-bounds -Warray-temporar
 
 # clang options
 CCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log
-CCOPT = -O2 -mavx -ftree-vectorize -fopt-info-optimized=opts.log
+CCOPT = -O2 -mavx2 -ftree-vectorize -fopt-info-optimized=opts.log
 CCOPT = -g -Wall -Wextra -O0
 
 # libraries

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -116,7 +116,7 @@ sphere_t* create ()
   spheres -> tmp = spheres -> t_z + size_t_z;
   spheres -> temp = spheres -> tmp + size_tmp;
   spheres -> mask = spheres -> temp + size_temp;
-  spheres -> list = spheres -> mask + size_mask;
+  spheres -> list = ( (int64_t*) (spheres -> mask + size_mask) );
   spheres -> id = spheres -> list + size_list;
 
   double* x = spheres -> x;

--- a/src/system.h
+++ b/src/system.h
@@ -7,7 +7,7 @@
 #define RADIUS 1.0
 #define CONTACT (2.0 * RADIUS)
 #define CONTACT2 (CONTACT * CONTACT)
-#define RANGE (1.25 * CONTACT)
+#define RANGE (4.0 * CONTACT)
 #define RANGE2 (RANGE * RANGE)
 #define EPSILON 1.0
 


### PR DESCRIPTION
- considers all possible particle images when computing the force
- clamps the maximum force to avert particles from jumping outside the system limits
- adds code that suppresses some compiler warnings
- BDS test code has been tested with volume fractions ranging from about 0.05 to 0.40