### PR TITLE
fixes pointer-issue in MSD computation [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -2635,9 +2635,9 @@ void test_bds ()
 
     // stores the current (unbounded) positions for the MSD computation:
 
-    t_x = r_x;
-    t_y = r_y;
-    t_z = r_z;
+    copy(r_x, t_x);
+    copy(r_y, t_y);
+    copy(r_z, t_z);
 
     // updates the particle positions by the action of the determinstic forces:
 

--- a/src/test.c
+++ b/src/test.c
@@ -162,7 +162,7 @@ int getinfo ()
   }
 
   const char fname[] = "params-bds.txt";
-  FILE* file = fopen(fname, "w");
+  FILE* file = fopen(fname, "r");
   if (file == NULL)
   {
     const char errmsg[] = "getinfo(): IO ERROR with file %s: %s\n";

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,15 @@ typedef union
 } alias_t;
 
 
+void copy (const double* restrict src, double* restrict dst)
+{
+  for (size_t i = 0; i != NUM_SPHERES; ++i)
+  {
+    dst[i] = src[i];
+  }
+}
+
+
 // implements Marsaglia's 64-bit xorshift, yields a uniformly distributed number in [0, 1)
 // uses a signed 64-bit integer for compatibility with FORTRAN
 double xorshift64 (int64_t* state)

--- a/src/util.h
+++ b/src/util.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+void copy (const double* restrict src, double* restrict dst);
 double xorshift64 (int64_t* state);
 
 void inrange (const double* restrict x, double* restrict bitmask);


### PR DESCRIPTION
pointers are like double-edged swords ... must have been thinking in FORTRAN when I wrote those lines in code in the first place

this also fixes unintentional writing of `params-bds.txt' introduced by merging `logging-errors', now `getinfo()` reads the parameters file instead of writing to it (obliterating its contents).