### PR TITLE
adds xor() method for seeding the PRNG [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -2894,4 +2894,5 @@ References:
 
 
 // TODO:
+// [ ] use (s)random() instead of (s)rand()
 // [x] consider all possible images when computing the interparticle forces


### PR DESCRIPTION
adds the xor() method for seeding the `rand()` Pseudo Random Number Generator PRNG
xor() uses the current time and the process ID to yield a seed