### PR TITLE
fixes minor seeding error [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -430,7 +430,10 @@ void seed (uint64_t* state)
       fprintf(stderr, "seed(): falling back to XORing\n");
       srandom(xor());
     }
-    srandom(prn);
+    else
+    {
+      srandom(prn);
+    }
     close(devurand);
   }
 #endif


### PR DESCRIPTION
COMMENTS:
Otherwise the code would have used the default value to seed stdlib's random() if reading from /dev/urandom fails.

This is flagged as a minor issue because it is highly unlikely that reading four bytes from /dev/urandom would fail (see `man urandom').