### PR TITLE
dumps the `running' status to file [clang]

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -3194,6 +3194,8 @@ void test_bds2()
     return;
   }
 
+  dumpstat("running");
+
   // executes the BDS integrator
 
   struct timespec end;


### PR DESCRIPTION
COMMENTS:
Dumps the `running' status to file to indicate that the BDS code is currently running.

This can be useful when cancelling several jobs ... a bash script could read the status files in directory hierarchy to determine which jobs are running to issue the `cancel' signal.