### PR TITLE
fixes multiple struct definitions [clang]

### DIFF
--- a/inc/util/random.h
+++ b/inc/util/random.h
@@ -14,16 +14,22 @@ struct generator {
   uint64_t* state;
   void (*seed) (struct generator*);
   double (*fetch) (struct generator*);
-} generator_t;
+};
+
+typedef struct generator generator_t;
 
 struct random
 {
-  struct generator* generator;
+  generator_t* generator;
   double (*fetch) (struct random*);
-} random_t;
+};
+
+typedef struct random random_t;
 
 struct iPRNG {
   void (*initializer) (struct random*, enum PRNG);
-} initPRNG_t;
+};
+
+typedef struct iPRNG iPRNG_t;
 
 #endif

--- a/inc/util/type.h
+++ b/inc/util/type.h
@@ -5,7 +5,9 @@
 
 struct util
 {
-  struct iPRNG random;		// PRNG initializer
-} util_t;
+  iPRNG_t random;		// PRNG initializer
+};
+
+typedef struct util util_t;
 
 #endif

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -8,7 +8,7 @@
 #define EXP(N) ( (N + BIAS) << 52 )
 
 
-static void seeder (struct generator* generator)
+static void seeder (generator_t* generator)
 {
   *generator -> state = 0xffffffffffffffff;
   *generator -> count = 0;
@@ -47,7 +47,7 @@ double sxorshift64 (int64_t* state)
 
 
 // as sxorshift64() but uses unsigned 64-bit integers to update the PRNG state
-static double xorshift64 (struct generator* generator)
+static double xorshift64 (generator_t* generator)
 {
   uint64_t x = *(generator -> state);
   x ^= (x << 13);
@@ -66,14 +66,14 @@ static double xorshift64 (struct generator* generator)
 
 
 // aliases Marsaglia's xorshift64() uniform pseudo random number generator
-static double urand (struct generator* generator)
+static double urand (generator_t* generator)
 {
   return xorshift64(generator);
 }
 
 
 // implements Böx-Muller's method to yield normally distributed pseudo-random numbers
-static double nrand (struct generator* generator)
+static double nrand (generator_t* generator)
 {
   double const inf = INFINITY;
   double x = inf;
@@ -91,16 +91,16 @@ static double nrand (struct generator* generator)
 }
 
 
-static double fetcher (struct random* random)
+static double fetcher (random_t* random)
 {
   return random -> generator -> fetch(random -> generator);
 }
 
 
 // initial version of the PRNG initializer, state seeding and binding
-void util_random_initializer (struct random* random, enum PRNG PRNG)
+void util_random_initializer (random_t* random, enum PRNG PRNG)
 {
-  struct generator* generator = random -> generator;
+  generator_t* generator = random -> generator;
   generator -> seed = seeder;
   if (PRNG == URAND)
   {

--- a/src/util/type/type.c
+++ b/src/util/type/type.c
@@ -1,11 +1,11 @@
 #include "util/type.h"
 
-extern void util_random_initializer(struct random*, enum PRNG);
+extern void util_random_initializer(random_t*, enum PRNG);
 
-static struct iPRNG const random = {
+static iPRNG_t const random = {
   .initializer = util_random_initializer
 };
 
-struct util const util = {
+util_t const util = {
   .random = random
 };


### PR DESCRIPTION
COMMENTS:
GCC 11.4.0 complained about multiple definitions of structs, this commit introduces typedefs to fix those issues

the side effect is that the source code is more readable