### PR TITLE
updates PRNG seeder() [clang]

### DIFF
--- a/inc/util/random.h
+++ b/inc/util/random.h
@@ -12,7 +12,7 @@ enum PRNG {		// Pseudo Random Number Generator
 struct generator {
   size_t* count;
   uint64_t* state;
-  void (*seed) (struct generator*);
+  int (*seed) (struct generator*);
   double (*fetch) (struct generator*);
 };
 
@@ -27,7 +27,7 @@ struct random
 typedef struct random random_t;
 
 struct iPRNG {
-  void (*initializer) (struct random*, enum PRNG);
+  int (*initializer) (struct random*, enum PRNG);
 };
 
 typedef struct iPRNG iPRNG_t;

--- a/src/test/random/test.c
+++ b/src/test/random/test.c
@@ -82,7 +82,14 @@ void test ()
   random -> generator -> state = (uint64_t*) iter;
   iter += sizeof(uint64_t);
 
-  util.random.initializer(random, NRAND);
+  int const stat = util.random.initializer(random, NRAND);
+  if (stat != 0)
+  {
+    free(data);
+    data = NULL;
+    fprintf(stderr, "test-random(): PRNG seeding error\n");
+    return;
+  }
 
   double* prns = malloc( NUMEL * sizeof(double) );
   if (prns == NULL)

--- a/src/util/type/type.c
+++ b/src/util/type/type.c
@@ -1,6 +1,6 @@
 #include "util/type.h"
 
-extern void util_random_initializer(random_t*, enum PRNG);
+extern int util_random_initializer(random_t*, enum PRNG);
 
 static iPRNG_t const random = {
   .initializer = util_random_initializer


### PR DESCRIPTION
COMMENTS:
for the time being XORs the current time and the process ID to seed the PRNG

complains if the seed is inadequate (that is, equal to zero) or if the time utility fails unexpectedly

complains at compile time if the underlying type of `time_t' is not 64-bits wide

uses bitmasking so that the caller can check if the seeding failed; if the Least Significan Bit LSB is set (with a non-zero value) that means that seeding failed and that the code should abort execution.

Note that Marsaglia's xorshift pseudo-random number generators must never be seeded with a zero value (for you will always fetch a zero value from the PRNG).

code passes existing tests