### PR TITLE
resets the PRNG upon depletion [clang]

### DIFF
--- a/inc/util/random.h
+++ b/inc/util/random.h
@@ -4,13 +4,15 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#define OBDS_ERR_PRNG ( (uint64_t) 0xfff0000000000000 )
+
 enum PRNG {		// Pseudo Random Number Generator
   URAND,		// Uniform PRNG
   NRAND			// Normal PRNG
 };
 
 struct generator {
-  size_t* count;
+  double* count;
   uint64_t* state;
   int (*seed) (struct generator*);
   double (*fetch) (struct generator*);


### PR DESCRIPTION
COMMENTS:
adds code for resetting the PRNG after it is depleted (that is, when count is equal to or greater than the period of the PRNG)

reset() simply gets a new seed and resets the PRNG counter

asserts the size of `int' to make sure that the SUCCESS and FAILURE MACROS fill all the bits (we do this even though we do not expect this to be necessary, yet it does not hurt do so)

uses a double to store the PRNG count because SIZE_MAX is equal to the PERIOD and so we cannot use `size_t' to check if the PRNG has rolled over (note that nrand() deplets the PRNG in unpredictable ways)

fetch() returns OBDS_ERR_PRNG if there's a seeding error because the caller will be at a better position to handle this error (in this case the caller `test()' frees the memory buffers to terminate gracefully)

Note that OBDS_ERR_PRNG is the 64-bit binary representation of negative infinity

code passes existing tests