### PR TITLE
refactors sphere [clang] [FORTRAN]

### DIFF
--- a/inc/bds/types.h
+++ b/inc/bds/types.h
@@ -1,7 +1,7 @@
 #ifndef GUARD_OPENBDS_BDS_TYPES_H
 #define GUARD_OPENBDS_BDS_TYPES_H
 
-#include<stdint.h>
+#include <stdint.h>
 
 union __OBDS_PROP_TYPE__
 {
@@ -12,3 +12,26 @@ union __OBDS_PROP_TYPE__
 typedef union __OBDS_PROP_TYPE__ prop_t;
 
 #endif
+
+/*
+
+OpenBDS							September 07, 2023
+
+source: bds/types.h
+author: @misael-diaz
+
+Synopsis:
+Defines the OpenBDS property type.
+Sometimes we operate on floats as if they were integers so this definition is quite handy.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/config.h
+++ b/inc/config.h
@@ -1,20 +1,25 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_CONFIG_H
+#define GUARD_OPENBDS_CONFIG_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include <stddef.h>
+
+#include "fconfig.h"
+
+#define CONF_NUM_PARTICLES ( (size_t) FCONF_NUM_PARTICLES )
+#define CONF_LIMIT ( (double) FCONF_LIMIT )
 
 #endif
 
 /*
 
-OpenBDS							September 05, 2023
+OpenBDS                                                 September 07, 2023
 
-source: system.h
+source: config.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Defines some parameters for configuring the Brownian Dynamics Simulations BDS.
+Do not edit this header file manually, edit the FORTRAN fconfig.h instead.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/fconfig.h
+++ b/inc/fconfig.h
@@ -1,20 +1,21 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_FORTRAN_CONFIG_H
+#define GUARD_OPENBDS_FORTRAN_CONFIG_H
 
-#include "system/params.h"
-#include "system/box.h"
+#define FCONF_NUM_PARTICLES 256
+#define FCONF_LIMIT 8.0
 
 #endif
 
 /*
 
-OpenBDS							September 05, 2023
+OpenBDS                                                 September 07, 2023
 
-source: system.h
+source: fconfig.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+FORTRAN configuration file for the Brownian Dynamics Simulations.
+Defines the number of particles and the system (cubic) box limit.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/particles/sphere.h
+++ b/inc/particles/sphere.h
@@ -1,8 +1,8 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_PARTICLES_SPHERE_H
+#define GUARD_OPENBDS_PARTICLES_SPHERE_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include "particles/sphere/params.h"
+#include "particles/sphere/type.h"
 
 #endif
 
@@ -10,11 +10,11 @@
 
 OpenBDS							September 05, 2023
 
-source: system.h
+source: particles/sphere.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Bundles the sphere type, properties, and parameters.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/particles/sphere/params.h
+++ b/inc/particles/sphere/params.h
@@ -1,0 +1,38 @@
+#ifndef GUARD_OPENBDS_PARTICLES_SPHERE_PARAMS_H
+#define GUARD_OPENBDS_PARTICLES_SPHERE_PARAMS_H
+
+#include "system/params.h"
+
+#define __OBDS_SPH_LIN_BROWNIAN_MOBILITY__ (1.4142135623730951 * __OBDS_SQRT_TIME_STEP__)
+#define __OBDS_SPH_ANG_BROWNIAN_MOBILITY__ (1.2247448713915890 * __OBDS_SQRT_TIME_STEP__)
+#define __OBDS_SPH_LIN_MOBILITY__  ( (double) ( __OBDS_TIME_STEP__ ) )
+
+#define __OBDS_SPH_RADIUS__ ( (double) 1.0 )
+#define __OBDS_SPH_DIAMETER__ ( (double) ( 2.0 * __OBDS_SPH_RADIUS__ ) )
+#define __OBDS_SPH_CONTACT__ ( (double) ( __OBDS_SPH_DIAMETER__ ) )
+
+#define __OBDS_NUM_SPHERES__ ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
+
+#endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: particles/sphere/params.h
+author: @misael-diaz
+
+Synopsis:
+Defines the sphere parameters.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/particles/sphere/type.h
+++ b/inc/particles/sphere/type.h
@@ -1,0 +1,67 @@
+#ifndef GUARD_OPENBDS_PARTICLES_SPHERE_TYPE_H
+#define GUARD_OPENBDS_PARTICLES_SPHERE_TYPE_H
+
+#include "bds/types.h"
+
+// defines the underlying properties of the sphere type:
+struct __OBDS_SPHERE_TYPE__
+{
+  // position subject to periodic boundaries:
+  prop_t* x;
+  prop_t* y;
+  prop_t* z;
+  // absolute position:
+  prop_t* r_x;
+  prop_t* r_y;
+  prop_t* r_z;
+  // angular position:
+  prop_t* a_x;
+  prop_t* a_y;
+  prop_t* a_z;
+  // force:
+  prop_t* f_x;
+  prop_t* f_y;
+  prop_t* f_z;
+  // torque:
+  prop_t* t_x;
+  prop_t* t_y;
+  prop_t* t_z;
+  // identifier:
+  prop_t* id;
+};
+
+typedef struct __OBDS_SPHERE_TYPE__ OBDS_Sphere_t;
+
+struct sphere
+{
+  OBDS_Sphere_t* props;			// properties
+  void (*update) (struct sphere*);	// updates the particles position and orientation
+  void (*limit) (struct sphere*);	// limits the particles to the system boundaries
+  void (*log) (const struct sphere*);	// logs the particles position and orientation
+};
+
+typedef struct sphere sphere_t;
+
+#endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: particles/sphere/type.h
+author: @misael-diaz
+
+Synopsis:
+Defines the sphere type and properties.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/particles/sphere/utils.h
+++ b/inc/particles/sphere/utils.h
@@ -1,20 +1,21 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_PARTICLES_SPHERE_UTILS_H
+#define GUARD_OPENBDS_PARTICLES_SPHERE_UTILS_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include "particles/sphere/type.h"
+
+sphere_t* particles_sphere_initializer(void*);
 
 #endif
 
 /*
 
-OpenBDS							September 05, 2023
+OpenBDS							September 07, 2023
 
-source: system.h
+source: particles/sphere/utils.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Defines an interface for the sphere utilities.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/system/box.h
+++ b/inc/system/box.h
@@ -1,11 +1,29 @@
 #ifndef GUARD_OPENBDS_SYSTEM_BOX_H
 #define GUARD_OPENBDS_SYSTEM_BOX_H
 
-#include "bds/types.h"
-
-#define LIMIT 8.0
-#define LENGTH (2.0 * LIMIT)
-
-void pbc(prop_t* restrict x, prop_t* restrict offset, prop_t* restrict bitmask);
+#include "system/box/params.h"
+#include "system/box/utils.h"
 
 #endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: system/box.h
+author: @misael-diaz
+
+Synopsis:
+Bundles the system box parameters and utils.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/system/box/params.h
+++ b/inc/system/box/params.h
@@ -1,8 +1,10 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_SYSTEM_BOX_PARAMS_H
+#define GUARD_OPENBDS_SYSTEM_BOX_PARAMS_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include "config.h"
+
+#define __OBDS_LIMIT__ ( (double) ( CONF_LIMIT ) )
+#define __OBDS_LENGTH__ ( (double) ( 2.0 * ( __OBDS_LIMIT__ ) ) )
 
 #endif
 
@@ -10,11 +12,11 @@
 
 OpenBDS							September 05, 2023
 
-source: system.h
+source: system/box/params.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Defines the system box (cubic) limits.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/system/box/utils.h
+++ b/inc/system/box/utils.h
@@ -1,8 +1,9 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_SYSTEM_BOX_UTILS_H
+#define GUARD_OPENBDS_SYSTEM_BOX_UTILS_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include "bds/types.h"
+
+void pbc(prop_t* restrict x, prop_t* restrict offset, prop_t* restrict bitmask);
 
 #endif
 
@@ -10,11 +11,11 @@
 
 OpenBDS							September 05, 2023
 
-source: system.h
+source: system/box/utils.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Defines the system box utils for applying periodic boundary conditions PBCs.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/system/params.h
+++ b/inc/system/params.h
@@ -1,0 +1,35 @@
+#ifndef GUARD_OPENBDS_SYSTEM_PARAMS_H
+#define GUARD_OPENBDS_SYSTEM_PARAMS_H
+
+#include "config.h"
+
+#define __OBDS_INV_SQRT_TIME_STEP__ ( (size_t) 0x100 )
+#define __OBDS_SQRT_TIME_STEP__ ( 1.0 / ( (double) ( __OBDS_INV_SQRT_TIME_STEP__ ) ) )
+#define __OBDS_INV_TIME_STEP__ (__OBDS_INV_SQRT_TIME_STEP__ * __OBDS_INV_SQRT_TIME_STEP__)
+#define __OBDS_TIME_STEP__ ( 1.0 / ( (double) ( __OBDS_INV_TIME_STEP__ ) ) )
+
+#define __OBDS_NUM_PARTICLES__ ( (size_t) ( CONF_NUM_PARTICLES ) )
+
+#endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: system/params.h
+author: @misael-diaz
+
+Synopsis:
+Defines system parameters, such as the time-step and the number of particles.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util.h
+++ b/inc/util.h
@@ -1,8 +1,9 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_UTIL_H
+#define GUARD_OPENBDS_UTIL_H
 
-#include "system/params.h"
-#include "system/box.h"
+#include "util/arrays.h"
+#include "util/random.h"
+#include "util/type.h"
 
 #endif
 
@@ -10,11 +11,11 @@
 
 OpenBDS							September 05, 2023
 
-source: system.h
+source: util.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Bundles the core utilities.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/util/arrays.h
+++ b/inc/util/arrays.h
@@ -1,10 +1,32 @@
 #ifndef GUARD_OPENBDS_UTIL_ARRAYS_H
 #define GUARD_OPENBDS_UTIL_ARRAYS_H
 
-#include <stdint.h>
+#include "bds/types.h"
 
-void copy (const double* restrict src, double* restrict dst);
-void zeros (double* x);
-void iota (int64_t* x);
+void copy (const prop_t* restrict src, prop_t* restrict dst);
+void zeros (prop_t* x);
+void iota (prop_t* x);
 
 #endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: util/arrays.h
+author: @misael-diaz
+
+Synopsis:
+Provides prototypes for utils that operate on arrays.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util/random.h
+++ b/inc/util/random.h
@@ -1,37 +1,29 @@
 #ifndef GUARD_OPENBDS_UTIL_RANDOM_H
 #define GUARD_OPENBDS_UTIL_RANDOM_H
 
-#include <stdint.h>
-#include <stddef.h>
-
-#define OBDS_ERR_PRNG ( (uint64_t) 0xfff0000000000000 )
-
-enum PRNG {		// Pseudo Random Number Generator
-  URAND,		// Uniform PRNG
-  NRAND			// Normal PRNG
-};
-
-struct generator {
-  double* count;
-  uint64_t* state;
-  int (*seed) (struct generator*);
-  double (*fetch) (struct generator*);
-};
-
-typedef struct generator generator_t;
-
-struct random
-{
-  generator_t* generator;
-  double (*fetch) (struct random*);
-};
-
-typedef struct random random_t;
-
-struct iPRNG {
-  int (*initializer) (struct random*, enum PRNG);
-};
-
-typedef struct iPRNG iPRNG_t;
+#include "util/random/err.h"
+#include "util/random/type.h"
 
 #endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: util/random.h
+author: @misael-diaz
+
+Synopsis:
+Defines the Pseudo Random Number Generator PRNG Utility.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util/random/err.h
+++ b/inc/util/random/err.h
@@ -1,8 +1,7 @@
-#ifndef GUARD_OPENBDS_SYSTEM_H
-#define GUARD_OPENBDS_SYSTEM_H
+#ifndef GUARD_OPENBDS_UTIL_RANDOM_ERR_H
+#define GUARD_OPENBDS_UTIL_RANDOM_ERR_H
 
-#include "system/params.h"
-#include "system/box.h"
+#define OBDS_ERR_PRNG ( (uint64_t) 0xfff0000000000000 )
 
 #endif
 
@@ -10,11 +9,11 @@
 
 OpenBDS							September 05, 2023
 
-source: system.h
+source: util/random/err.h
 author: @misael-diaz
 
 Synopsis:
-Bundles system parameters and utilities.
+Defines the Pseudo Random Number Generator PRNG Error MACRO.
 
 Copyright (c) 2023 Misael Diaz-Maldonado
 This file is released under the GNU General Public License as published

--- a/inc/util/random/type.h
+++ b/inc/util/random/type.h
@@ -1,0 +1,56 @@
+#ifndef GUARD_OPENBDS_UTIL_RANDOM_TYPE_H
+#define GUARD_OPENBDS_UTIL_RANDOM_TYPE_H
+
+#include <stdint.h>
+
+enum PRNG {		// Pseudo Random Number Generator
+  URAND,		// Uniform PRNG
+  NRAND			// Normal PRNG
+};
+
+struct generator {
+  double* count;
+  uint64_t* state;
+  int (*seed) (struct generator*);
+  double (*fetch) (struct generator*);
+};
+
+typedef struct generator generator_t;
+
+struct random
+{
+  generator_t* generator;
+  double (*fetch) (struct random*);
+};
+
+typedef struct random random_t;
+
+struct iPRNG {
+  int (*initializer) (struct random*, enum PRNG);
+};
+
+typedef struct iPRNG iPRNG_t;
+
+#endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: util/random/type.h
+author: @misael-diaz
+
+Synopsis:
+Defines the Pseudo Random Number Generator PRNG types.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util/type.h
+++ b/inc/util/type.h
@@ -11,3 +11,25 @@ struct util
 typedef struct util util_t;
 
 #endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: util/type.h
+author: @misael-diaz
+
+Synopsis:
+Defines a namespace for some utilities.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,10 +17,12 @@
 include make-inc
 
 export CC
+export FC
 export CCOPT
+export FCOPT
 export LIBS
 
-all: $(TESTS) utils system-utils tests
+all: $(TESTS) utils system-utils particle-utils tests
 
 $(MAIN_BIN): $(UTIL_OBJ) $(SPHERE_OBJ) $(MAIN_OBJ)
 	$(FC) $(FCOPT) $(UTIL_OBJ) $(SPHERE_OBJ) $(MAIN_OBJ) -o $(MAIN_BIN)
@@ -46,11 +48,15 @@ utils:
 system-utils:
 	@$(MAKE) -C system
 
+particle-utils: utils
+	@$(MAKE) -C particles
+
 tests: utils
 	@$(MAKE) -C test
 
 clean:
-	/bin/rm -rf *.o *.mod *.bin
+	/bin/rm -rf *.o *.log *.mod *.bin
 	@$(MAKE) -C util clean
 	@$(MAKE) -C system clean
+	@$(MAKE) -C particles clean
 	@$(MAKE) -C test clean

--- a/src/particles/Makefile
+++ b/src/particles/Makefile
@@ -14,12 +14,10 @@
 # (at your option) any later version.
 #
 
-include make-inc
+all: spheres
 
-all: $(ARRAYS_O)
-
-$(ARRAYS_O): $(SYSTEM_H) $(ARRAYS_H) $(ARRAYS_C)
-	$(CC) $(INC) $(CCOPT) -c $(ARRAYS_C) -o $(ARRAYS_O)
+spheres:
+	@$(MAKE) -C sphere
 
 clean:
-	/bin/rm -f *.log *.o
+	@$(MAKE) -C sphere clean

--- a/src/particles/sphere/Makefile
+++ b/src/particles/sphere/Makefile
@@ -16,10 +16,10 @@
 
 include make-inc
 
-all: $(ARRAYS_O)
+all: $(SPHERE_O)
 
-$(ARRAYS_O): $(SYSTEM_H) $(ARRAYS_H) $(ARRAYS_C)
-	$(CC) $(INC) $(CCOPT) -c $(ARRAYS_C) -o $(ARRAYS_O)
+$(SPHERE_O): $(SYSBOX_H) $(ARRAYS_H) $(SPHERE_H) $(SPHERE_C)
+	$(CC) $(INC) $(CCOPT) -c $(SPHERE_C) -o $(SPHERE_O)
 
 clean:
 	/bin/rm -f *.log *.o

--- a/src/particles/sphere/make-inc
+++ b/src/particles/sphere/make-inc
@@ -1,0 +1,28 @@
+#
+# OpenBDS						July 19, 2023
+#
+# source: make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# include
+INC = -I../../../inc
+
+# headers
+SYSBOX_H = ../../../inc/system/box.h
+SPHERE_H = ../../../inc/particles/sphere.h
+ARRAYS_H = ../../../inc/util/arrays.h
+
+# sources
+SPHERE_C = sphere.c
+
+# objects
+SPHERE_O = sphere.o

--- a/src/particles/sphere/sphere.c
+++ b/src/particles/sphere/sphere.c
@@ -1,0 +1,255 @@
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "system/box.h"
+#include "particles/sphere/params.h"
+#include "particles/sphere/type.h"
+#include "util/arrays.h"
+
+#define STDC17 201710L
+#define LIMIT ( (double) ( __OBDS_LIMIT__ ) )
+#define SIZED ( (double) ( __OBDS_NUM_SPHERES__ ) )
+#define TSTEP ( (double) ( __OBDS_TIME_STEP__ ) )
+#define NUMEL ( (size_t) ( __OBDS_NUM_SPHERES__ ) )
+#define RADIUS ( (double) ( __OBDS_SPH_RADIUS__ ) )
+#define CONTACT ( (double) ( __OBDS_SPH_CONTACT__ ) )
+#define MANTISSA ( (uint64_t) 0x000fffffffffffff )
+
+static void grid (prop_t* restrict xprop, prop_t* restrict yprop, prop_t* restrict zprop)
+{
+  // gets the number of spheres (at contact) that can be fitted along any dimension:
+
+  size_t const count = (LIMIT / RADIUS);
+  size_t const count2 = (count * count);
+
+  // sets particles at grid locations:
+
+  double* x = &xprop[0].data;
+  for (size_t n = 0; n != NUMEL; ++n)
+  {
+    size_t const i = (n % count);
+    double const pos = RADIUS + CONTACT * ( (double) i );
+    x[n] = pos;
+  }
+
+  double* y = &yprop[0].data;
+  for (size_t n = 0; n != NUMEL; ++n)
+  {
+    size_t const i = (n % count2) / count;
+    double const pos = RADIUS + CONTACT * ( (double) i );
+    y[n] = pos;
+  }
+
+  double* z = &zprop[0].data;
+  for (size_t n = 0; n != NUMEL; ++n)
+  {
+    size_t const i = (n / count2);
+    double const pos = RADIUS + CONTACT * ( (double) i );
+    z[n] = pos;
+  }
+
+  // shifts the particles so that their coordinates are in the range [-LIMIT, +LIMIT]:
+
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    x[i] -= LIMIT;
+  }
+
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    y[i] -= LIMIT;
+  }
+
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    z[i] -= LIMIT;
+  }
+}
+
+
+static void updater (sphere_t* spheres)
+{
+  printf("x: %+.16e\n", spheres -> props -> x -> data);
+}
+
+
+// applies periodic boundary conditions PBCs on the position vectors
+static void limiter (sphere_t* spheres)
+{
+  // NOTE: the torque is used as a temporary placeholder for now
+  pbc(spheres -> props -> x, spheres -> props -> t_x, spheres -> props -> t_y);
+  pbc(spheres -> props -> y, spheres -> props -> t_x, spheres -> props -> t_y);
+  pbc(spheres -> props -> z, spheres -> props -> t_x, spheres -> props -> t_y);
+}
+
+
+static void logger (const sphere_t* spheres)
+{
+  printf("x: %+.16e\n", spheres -> props -> x -> data);
+}
+
+
+sphere_t* particles_sphere_initializer (void* data)
+{
+  // compile-time sane checks:
+
+#if __STDC_VERSION__ > STDC17
+  static_assert(sizeof(NUMEL) == 8);
+  static_assert(sizeof(RADIUS) == 8);
+  static_assert(sizeof(CONTACT) == 8);
+  static_assert(sizeof(OBDS_Sphere_t) == 128);
+  static_assert(sizeof(size_t) == sizeof(uint64_t));
+  static_assert(sizeof(sphere_t) == 32);
+  static_assert(sizeof(prop_t) == 8);
+  static_assert(NUMEL != 0);
+  static_assert(NUMEL % 2 == 0);
+  static_assert(SIZE_MAX == UINT64_MAX);
+  static_assert(NUMEL <= 0x7ffffffffffffffe);
+  static_assert( SIZED * (RADIUS * RADIUS * RADIUS) < (LIMIT * LIMIT * LIMIT) );
+  static_assert(CONTACT == 2.0);
+  static_assert(RADIUS == 1.0);
+#else
+  _Static_assert(sizeof(NUMEL) == 8);
+  _Static_assert(sizeof(RADIUS) == 8);
+  _Static_assert(sizeof(CONTACT) == 8);
+  _Static_assert(sizeof(OBDS_Sphere_t) == 128);
+  _Static_assert(sizeof(size_t) == sizeof(uint64_t));
+  _Static_assert(sizeof(sphere_t) == 32);
+  _Static_assert(sizeof(prop_t) == 8);
+  _Static_assert(NUMEL != 0);
+  _Static_assert(NUMEL % 2 == 0);
+  _Static_assert(SIZE_MAX == UINT64_MAX);
+  _Static_assert(NUMEL <= 0x7fffffffffffffff);
+  _Static_assert( SIZED * (RADIUS * RADIUS * RADIUS) < (LIMIT * LIMIT * LIMIT) );
+  _Static_assert(CONTACT == 2.0);
+  _Static_assert(RADIUS == 1.0);
+#endif
+
+  // runtime sane checks:
+
+  prop_t const dt = { .data = TSTEP };
+  uint64_t const bin = dt.bin;
+  uint64_t const mantissa = (bin & MANTISSA);
+  if (mantissa != 0)
+  {
+    errno = EINVAL;
+    char err[] = "sphere-initializer() expects the time-step to be a power of two: %s\n";
+    fprintf(stderr, err, strerror(errno));
+    return nullptr;
+  }
+
+  // bindinds:
+
+  void* iter = data;
+  sphere_t* spheres = (sphere_t*) iter;
+  iter += sizeof(sphere_t);
+
+  spheres -> props = (OBDS_Sphere_t*) iter;
+  iter += sizeof(OBDS_Sphere_t);
+
+  spheres -> props -> x = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> y = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> z = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> props -> r_x = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> r_y = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> r_z = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> props -> a_x = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> a_y = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> a_z = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> props -> f_x = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> f_y = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> f_z = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> props -> t_x = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> t_y = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+  spheres -> props -> t_z = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> props -> id = (prop_t*) iter;
+  iter += NUMEL * sizeof(prop_t);
+
+  spheres -> update = updater;
+  spheres -> limit = limiter;
+  spheres -> log = logger;
+
+  prop_t* x = spheres -> props -> x;
+  prop_t* y = spheres -> props -> y;
+  prop_t* z = spheres -> props -> z;
+  prop_t* r_x = spheres -> props -> r_x;
+  prop_t* r_y = spheres -> props -> r_y;
+  prop_t* r_z = spheres -> props -> r_z;
+  prop_t* a_x = spheres -> props -> a_x;
+  prop_t* a_y = spheres -> props -> a_y;
+  prop_t* a_z = spheres -> props -> a_z;
+  prop_t* f_x = spheres -> props -> f_x;
+  prop_t* f_y = spheres -> props -> f_y;
+  prop_t* f_z = spheres -> props -> f_z;
+  prop_t* t_x = spheres -> props -> t_x;
+  prop_t* t_y = spheres -> props -> t_y;
+  prop_t* t_z = spheres -> props -> t_z;
+  prop_t* id = spheres -> props -> id;
+
+  // initializations:
+
+  zeros(x);
+  zeros(y);
+  zeros(z);
+  zeros(r_x);
+  zeros(r_y);
+  zeros(r_z);
+  zeros(a_x);
+  zeros(a_y);
+  zeros(a_z);
+  zeros(f_x);
+  zeros(f_y);
+  zeros(f_z);
+  zeros(t_x);
+  zeros(t_y);
+  zeros(t_z);
+  iota(id);
+
+  grid(x, y, z);
+
+  return spheres;
+}
+
+
+/*
+
+OpenBDS							September 06, 2023
+
+source: particles/sphere/sphere.c
+author: @misael-diaz
+
+Synopsis:
+Implements methods for spheres.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/system/box/Makefile
+++ b/src/system/box/Makefile
@@ -22,4 +22,4 @@ $(BOX_O): $(SYSTEM_H) $(BOX_H) $(BOX_C)
 	$(CC) $(INC) $(CCOPT) -c $(BOX_C) -o $(BOX_O)
 
 clean:
-	/bin/rm -f *.o
+	/bin/rm -f *.log *.o

--- a/src/system/box/box.c
+++ b/src/system/box/box.c
@@ -1,12 +1,10 @@
-#include <stddef.h>
-#include <stdint.h>
-
-#include "system.h"
-#include "system/box.h"
+#include "system/params.h"
+#include "system/box/params.h"
 #include "bds/types.h"
 
-#define NUMEL NUM_PARTICLES
-#define MSBMASK 0x8000000000000000
+#define NUMEL ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
+#define LIMIT ( (double) ( __OBDS_LIMIT__ ) )
+#define MSBMASK ( (uint64_t) 0x8000000000000000 )
 
 
 // gets the 11-bits that comprise the exponent of a double precision floating-point number
@@ -149,7 +147,7 @@ void pbc (prop_t* restrict x, prop_t* restrict distance, prop_t* restrict bitmas
 
 OpenBDS								September 05, 2023
 
-source: box.c
+source: system/box/box.c
 author: @misael-diaz
 
 Synopsis:

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -14,7 +14,7 @@
 # (at your option) any later version.
 #
 
-all: PRNGs util-system-box
+all: PRNGs util-system-box spheres
 
 PRNGs:
 	@$(MAKE) -C random
@@ -22,6 +22,10 @@ PRNGs:
 util-system-box:
 	@$(MAKE) -C system-box
 
+spheres:
+	@$(MAKE) -C particles-sphere
+
 clean:
 	@$(MAKE) -C random clean
 	@$(MAKE) -C system-box clean
+	@$(MAKE) -C particles-sphere clean

--- a/src/test/particles-sphere/Makefile
+++ b/src/test/particles-sphere/Makefile
@@ -16,10 +16,19 @@
 
 include make-inc
 
-all: $(ARRAYS_O)
+all: $(TEST) $(FEST)
 
-$(ARRAYS_O): $(SYSTEM_H) $(ARRAYS_H) $(ARRAYS_C)
-	$(CC) $(INC) $(CCOPT) -c $(ARRAYS_C) -o $(ARRAYS_O)
+$(TEST): $(TEST_O)
+	$(CC) $(INC) $(CCOPT) $(DEPS_O) $(TEST_O) -o $(TEST) $(LIBS)
+
+$(FEST): $(FEST_O)
+	$(FC) $(INC) $(FCOPT) $(DEPS_O) $(FEST_O) -o $(FEST)
+
+$(TEST_O): $(DEPS_O) $(TEST_C)
+	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
+
+$(FEST_O): $(TEST_F)
+	$(FC) $(INC) $(FCOPT) -c $(TEST_F) -o $(FEST_O)
 
 clean:
-	/bin/rm -f *.log *.o
+	/bin/rm -f *.o *.log *.mod *.bin

--- a/src/test/particles-sphere/make-inc
+++ b/src/test/particles-sphere/make-inc
@@ -1,0 +1,33 @@
+#
+# OpenBDS						July 19, 2023
+#
+# source: make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# include
+INC = -I../../../inc
+
+# sources
+TEST_C = test.c
+TEST_F = test.f
+
+# objects
+SYSBOX_O = ../../system/box/box.o
+ARRAYS_O = ../../util/array/arrays.o
+SPHERE_O = ../../particles/sphere/sphere.o
+DEPS_O = $(SYSBOX_O) $(ARRAYS_O) $(SPHERE_O)
+TEST_O = test.o
+FEST_O = fest.o
+
+# binaries
+TEST = test-particles-sphere.bin
+FEST = fortran-test-particles-sphere.bin

--- a/src/test/particles-sphere/test.c
+++ b/src/test/particles-sphere/test.c
@@ -1,0 +1,137 @@
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include "system/box/params.h"
+#include "particles/sphere/params.h"
+#include "particles/sphere/utils.h"
+
+#define STDC17 201710L
+#define LIMIT ( (double) ( __OBDS_LIMIT__ ) )
+#define NUMEL ( (size_t) ( __OBDS_NUM_SPHERES__ ) )
+#define PROPS ( (size_t) ( 16 * ( NUMEL ) ) )
+
+void test(void);
+
+int main ()
+{
+  test();
+  return 0;
+}
+
+
+#if __STDC_VERSION__ > STDC17
+void test (void)
+{
+  static_assert(sizeof(sphere_t) == 32);
+  static_assert(sizeof(OBDS_Sphere_t) == 128);
+  static_assert(sizeof(prop_t) == 8);
+  constexpr size_t sz = sizeof(sphere_t) + sizeof(OBDS_Sphere_t) + PROPS * sizeof(prop_t);
+  void* workspace = malloc(sz);
+  if (workspace == nullptr)
+  {
+    fprintf(stderr, "test-spheres(): memory allocation error %s\n", strerror(errno));
+
+    return;
+  }
+
+  sphere_t* spheres = particles_sphere_initializer(workspace);
+
+  double* x = &(spheres -> props -> x -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    *x = 1.0009765625 * LIMIT;
+    ++x;
+  }
+
+  double* y = &(spheres -> props -> y -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    *y = 1.0009765625 * LIMIT;
+    ++y;
+  }
+
+  double* z = &(spheres -> props -> z -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    *z = 1.0009765625 * LIMIT;
+    ++z;
+  }
+
+  spheres -> limit(spheres);
+
+  bool failed = false;
+  x = &(spheres -> props -> x -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    if (x[i] < -LIMIT || x[i] > +LIMIT)
+    {
+      failed = true;
+      break;
+    }
+  }
+
+  y = &(spheres -> props -> y -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    if (y[i] < -LIMIT || y[i] > +LIMIT)
+    {
+      failed = true;
+      break;
+    }
+  }
+
+  z = &(spheres -> props -> z -> data);
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    if (z[i] < -LIMIT || z[i] > +LIMIT)
+    {
+      failed = true;
+      break;
+    }
+  }
+
+  printf("test-sphere[0]: ");
+  if (failed)
+  {
+    printf("FAIL\n");
+  }
+  else
+  {
+    printf("PASS\n");
+  }
+
+  free(workspace);
+  workspace = NULL;
+}
+#else
+void test (void)
+{
+  printf("test-sphere[0]: UNIMPLEMENTED\n");
+}
+#endif
+
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: test/particles-sphere/test.c
+author: @misael-diaz
+
+Synopsis:
+Tests the methods that update the spheres.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/test/particles-sphere/test.f
+++ b/src/test/particles-sphere/test.f
@@ -1,0 +1,196 @@
+#include "fconfig.h"
+
+#define LIMIT FCONF_LIMIT
+#define NUMEL FCONF_NUM_PARTICLES
+
+module api
+  use, intrinsic :: iso_c_binding, only: c_ptr
+  use, intrinsic :: iso_c_binding, only: c_funptr
+  implicit none
+  private
+
+  public :: OBDS_Sphere_t
+  public :: sphere_t
+  public :: limiter
+  public :: c_malloc
+  public :: c_free
+  public :: c_init
+
+  ! sphere types defined in the header particles/sphere/type.h
+
+  type, bind(c) :: OBDS_Sphere_t
+    type(c_ptr) :: x
+    type(c_ptr) :: y
+    type(c_ptr) :: z
+    type(c_ptr) :: r_x
+    type(c_ptr) :: r_y
+    type(c_ptr) :: r_z
+    type(c_ptr) :: a_x
+    type(c_ptr) :: a_y
+    type(c_ptr) :: a_z
+    type(c_ptr) :: f_x
+    type(c_ptr) :: f_y
+    type(c_ptr) :: f_z
+    type(c_ptr) :: t_x
+    type(c_ptr) :: t_y
+    type(c_ptr) :: t_z
+    type(c_ptr) :: id
+  end type
+
+  type, bind(c) :: sphere_t
+    type(c_ptr) :: props
+    type(c_funptr) :: update
+    type(c_funptr) :: limit
+    type(c_funptr) :: log
+  end type
+
+  interface
+    function c_malloc (sz) bind(c, name = 'malloc') result(p)
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      use, intrinsic :: iso_c_binding, only: c_size_t
+      implicit none
+      integer(kind = c_size_t), value :: sz
+      type(c_ptr) :: p
+    end function
+  end interface
+
+  interface
+    subroutine c_free (p) bind(c, name = 'free')
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      implicit none
+      type(c_ptr), value :: p
+    end subroutine
+  end interface
+
+  interface
+    function c_init (workspace) bind(c, name = 'particles_sphere_initializer') result(sph)
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      implicit none
+      type(c_ptr), value :: workspace
+      type(c_ptr) :: sph
+    end function
+  end interface
+
+  interface
+    subroutine limiter (spheres)
+      import sphere_t
+      implicit none
+      type(sphere_t), intent(inout) :: spheres
+    end subroutine
+  end interface
+
+end module api
+
+program main
+  use, intrinsic :: iso_c_binding, only: c_ptr
+  use, intrinsic :: iso_c_binding, only: c_bool
+  use, intrinsic :: iso_c_binding, only: c_size_t
+  use, intrinsic :: iso_c_binding, only: c_double
+  use, intrinsic :: iso_c_binding, only: c_associated
+  use, intrinsic :: iso_c_binding, only: c_f_procpointer
+  use, intrinsic :: iso_c_binding, only: c_f_pointer
+  use, intrinsic :: iso_c_binding, only: c_null_ptr
+  use api, only: OBDS_Sphere_t
+  use api, only: sphere_t
+  use api, only: limiter
+  use api, only: c_malloc
+  use api, only: c_free
+  use api, only: c_init
+  implicit none
+
+  type(c_ptr) :: workspace = c_null_ptr
+  type(c_ptr) :: c_spheres = c_null_ptr
+  type(sphere_t), pointer :: spheres => null()
+  type(OBDS_Sphere_t), pointer :: props => null()
+  procedure(limiter), pointer :: limit => null()
+  real(kind = c_double), pointer, contiguous :: x(:) => null()
+  real(kind = c_double), pointer, contiguous :: y(:) => null()
+  real(kind = c_double), pointer, contiguous :: z(:) => null()
+  real(kind = c_double), parameter :: lim = real(LIMIT, kind = c_double)
+  integer(kind = c_size_t), parameter :: numel = int(NUMEL, kind = c_size_t)
+  integer(kind = c_size_t), parameter :: size_sphere_t = 32_c_size_t
+  integer(kind = c_size_t), parameter :: size_OBDS_Sphere_t = 128_c_size_t
+  integer(kind = c_size_t), parameter :: size_prop_t = 8_c_size_t
+  integer(kind = c_size_t), parameter :: sz = size_sphere_t + &
+                                            & size_OBDS_Sphere_t + &
+                                            & 16_c_size_t * numel * size_prop_t
+  logical(kind = c_bool) :: failed = .false.
+  integer(kind = c_size_t) :: i
+
+  workspace = c_malloc(sz)                      ! allocates workspace on the heap
+  c_spheres = c_init(workspace)                 ! initializes the sphere properties
+  call c_f_pointer(c_spheres, spheres)          ! binds to the C spheres container
+  call c_f_pointer(spheres % props, props)      ! binds to the sphere properties
+  call c_f_pointer(props % x, x, [numel])       ! binds to the x positions of the spheres
+  call c_f_pointer(props % y, y, [numel])       ! binds to the y positions of the spheres
+  call c_f_pointer(props % z, z, [numel])       ! binds to the z positions of the spheres
+  call c_f_procpointer(spheres % limit, limit)  ! binds to the type-bound limit() method
+
+  ! puts the particles outside the box (we can afford particle overlapping in this test)
+
+  x = 1.0009765625_c_double * lim
+  y = 1.0009765625_c_double * lim
+  z = 1.0009765625_c_double * lim
+
+  call limit(spheres)                           ! applies periodic boundary conditions
+
+  ! we can afford not to break the loops right away since the computing cost is just O(N)
+  do i = 1, numel
+    if (x(i) < -lim .or. x(i) > +lim) then
+      failed = .true.
+    end if
+  end do
+
+  do i = 1, numel
+    if (y(i) < -lim .or. y(i) > +lim) then
+      failed = .true.
+    end if
+  end do
+
+  do i = 1, numel
+    if (z(i) < -lim .or. z(i) > +lim) then
+      failed = .true.
+    end if
+  end do
+
+  ! checks if the limit() method failed to limit the particles to the system box
+
+  write (*, '(A)', advance = 'no') 'test-sphere[0]: '
+  if (failed) then
+    print '(A)', 'FAIL'
+  else
+    print '(A)', 'PASS'
+  end if
+
+  call c_free(workspace)                        ! frees workspace from memory
+  workspace = c_null_ptr                        ! nullifies pointer to workspace
+
+end program main
+
+!   OpenBDS                                                     September 07, 2023
+!
+!   source: test.f
+!   author: @misael-diaz
+!
+!   Synopsis:
+!   Tests the limiter method which applies the periodic boundary conditions.
+!
+!   Copyright (C) 2023 Misael Diaz-Maldonado
+!
+!   This program is free software: you can redistribute it and/or modify
+!   it under the terms of the GNU General Public License as published by
+!   the Free Software Foundation, either version 3 of the License, or
+!   (at your option) any later version.
+!
+!   This program is distributed in the hope that it will be useful,
+!   but WITHOUT ANY WARRANTY; without even the implied warranty of
+!   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!   GNU General Public License for more details.
+!
+!   You should have received a copy of the GNU General Public License
+!   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!   References:
+!   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+!   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+!   [2] S Kim and S Karrila, Microhydrodynamics.

--- a/src/test/random/Makefile
+++ b/src/test/random/Makefile
@@ -25,4 +25,4 @@ $(TEST_O): $(RANDOM_H) $(RANDOM_O) $(TYPE_O) $(TEST_C)
 	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
 
 clean:
-	/bin/rm -f *.o *.bin
+	/bin/rm -f *.o *.log *.bin

--- a/src/test/random/test.c
+++ b/src/test/random/test.c
@@ -175,3 +175,26 @@ void test ()
   data = NULL;
   prns = NULL;
 }
+
+
+/*
+
+OpenBDS							September 07, 2023
+
+source: test/random/test.c
+author: @misael-diaz
+
+Synopsis:
+Tests the Pseudo Random Number Generator PRNG implementation.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/test/system-box/Makefile
+++ b/src/test/system-box/Makefile
@@ -25,4 +25,4 @@ $(TEST_O): $(SYSTEM_H) $(BOX_H) $(BOX_O) $(TEST_C)
 	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
 
 clean:
-	/bin/rm -f *.o *.bin
+	/bin/rm -f *.o *.log *.bin

--- a/src/test/system-box/test.c
+++ b/src/test/system-box/test.c
@@ -1,12 +1,12 @@
 #include <stdio.h>
-#include <stddef.h>
 #include <stdbool.h>
 
-#include "system.h"
-#include "system/box.h"
-#include "bds/types.h"
+#include "system/params.h"
+#include "system/box/params.h"
+#include "system/box/utils.h"
 
-#define NUMEL NUM_PARTICLES
+#define NUMEL ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
+#define LIMIT ( (double) ( __OBDS_LIMIT__ ) )
 
 void test(void);
 
@@ -71,7 +71,7 @@ void test (void)
 
 OpenBDS							September 05, 2023
 
-source: test.c
+source: test/system-box/test.c
 author: @misael-diaz
 
 Synopsis:

--- a/src/util/array/arrays.c
+++ b/src/util/array/arrays.c
@@ -1,30 +1,34 @@
 #include <stddef.h>
 #include "util/arrays.h"
-#include "system.h"
+#include "system/params.h"
 
-#define NUMEL NUM_PARTICLES
+#define NUMEL ( (size_t) __OBDS_NUM_PARTICLES__ )
 
-void copy (const double* restrict src, double* restrict dst)
+void copy (const prop_t* restrict source, prop_t* restrict dest)
 {
+  double* dst = &dest[0].data;
+  const double* src = &source[0].data;
   for (size_t i = 0; i != NUMEL; ++i)
   {
     dst[i] = src[i];
   }
 }
 
-void zeros (double* x)
+void zeros (prop_t* x)
 {
+  double* data = &x[0].data;
   for (size_t i = 0; i != NUMEL; ++i)
   {
-    x[i] = 0.0;
+    data[i] = 0.0;
   }
 }
 
-void iota (int64_t* x)
+void iota (prop_t* ID)
 {
+  uint64_t* id = &ID[0].bin;
   for (size_t i = 0; i != NUMEL; ++i)
   {
-    x[i] = i;
+    id[i] = i;
   }
 }
 
@@ -32,7 +36,7 @@ void iota (int64_t* x)
 
 OpenBDS								July 19, 2023
 
-source: arrays.c
+source: util/array/arrays.c
 author: @misael-diaz
 
 Synopsis:

--- a/src/util/random/Makefile
+++ b/src/util/random/Makefile
@@ -22,4 +22,4 @@ $(RANDOM_O): $(RANDOM_H) $(RANDOM_C)
 	$(CC) $(INC) $(CCOPT) -c $(RANDOM_C) -o $(RANDOM_O)
 
 clean:
-	/bin/rm -f *.o
+	/bin/rm -f *.log *.o

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -251,7 +251,7 @@ int util_random_initializer (random_t* random, enum PRNG PRNG)
 
 OpenBDS								July 19, 2023
 
-source: random.c
+source: util/random/random.c
 author: @misael-diaz
 
 Synopsis:

--- a/src/util/type/Makefile
+++ b/src/util/type/Makefile
@@ -22,4 +22,4 @@ $(TYPE_O): $(TYPE_H) $(TYPE_C)
 	$(CC) $(INC) $(CCOPT) -c $(TYPE_C) -o $(TYPE_O)
 
 clean:
-	/bin/rm -f *.o
+	/bin/rm -f *.log *.o

--- a/src/util/type/type.c
+++ b/src/util/type/type.c
@@ -9,3 +9,25 @@ static iPRNG_t const random = {
 util_t const util = {
   .random = random
 };
+
+/*
+
+OpenBDS								September 07, 2023
+
+source: util/type/type.c
+author: @misael-diaz
+
+Synopsis:
+Initializes the util object of type `util_t' (which is effectively a namespace).
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/


### PR DESCRIPTION
COMMENTS:
- no gcc warnings on refactored code
- uses some features from the C23 standard
- uses some features from the FORTRAN 2003 standard
- adds descriptions to header and source files
- refactors some headers (for better or worse)
- code passes trivial periodic boundary condition test
- valgrind reports no memory issues