### PR TITLE
adds methods for spheres [clang] [FORTRAN]

### DIFF
--- a/inc/particles/sphere/params.h
+++ b/inc/particles/sphere/params.h
@@ -10,6 +10,8 @@
 #define __OBDS_SPH_RADIUS__ ( (double) 1.0 )
 #define __OBDS_SPH_DIAMETER__ ( (double) ( 2.0 * __OBDS_SPH_RADIUS__ ) )
 #define __OBDS_SPH_CONTACT__ ( (double) ( __OBDS_SPH_DIAMETER__ ) )
+#define __OBDS_SPH_RANGE__ ( (double) ( 4.0 * ( __OBDS_SPH_CONTACT__ ) ) )
+#define __OBDS_SPH_EPSILON__ ( (double) 1.0 )
 
 #define __OBDS_NUM_SPHERES__ ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
 

--- a/inc/particles/sphere/type.h
+++ b/inc/particles/sphere/type.h
@@ -3,6 +3,15 @@
 
 #include "bds/types.h"
 
+// defines enum for selecting the logging level
+enum SPHLOG
+{
+  SPH_LOG_LEVEL_DEFAULT,
+  SPH_LOG_LEVEL_VERBOSE
+};
+
+typedef enum SPHLOG SPHLOG;
+
 // defines the underlying properties of the sphere type:
 struct __OBDS_SPHERE_TYPE__
 {
@@ -37,7 +46,7 @@ struct sphere
   OBDS_Sphere_t* props;			// properties
   void (*update) (struct sphere*);	// updates the particles position and orientation
   void (*limit) (struct sphere*);	// limits the particles to the system boundaries
-  void (*log) (const struct sphere*);	// logs the particles position and orientation
+  int (*log) (const struct sphere* spheres, size_t const step);	// logs the positions
 };
 
 typedef struct sphere sphere_t;

--- a/inc/particles/sphere/utils.h
+++ b/inc/particles/sphere/utils.h
@@ -3,7 +3,7 @@
 
 #include "particles/sphere/type.h"
 
-sphere_t* particles_sphere_initializer(void*);
+sphere_t* particles_sphere_initializer(void*, SPHLOG);
 
 #endif
 

--- a/src/make-inc
+++ b/src/make-inc
@@ -14,9 +14,11 @@
 #
 
 # FORTRAN compiler
+FC = gfortran-10
 FC = gfortran
 
 # clang compiler
+CC = gcc-10
 CC = gcc
 
 FCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffree-form\

--- a/src/test/particles-sphere/test.f
+++ b/src/test/particles-sphere/test.f
@@ -63,10 +63,12 @@ module api
   end interface
 
   interface
-    function c_init (workspace) bind(c, name = 'particles_sphere_initializer') result(sph)
+    function c_init (ptr, lvl) bind(c, name = 'particles_sphere_initializer') result(sph)
       use, intrinsic :: iso_c_binding, only: c_ptr
+      use, intrinsic :: iso_c_binding, only: c_int
       implicit none
-      type(c_ptr), value :: workspace
+      type(c_ptr), value :: ptr                 ! pointer to workspace
+      integer(kind = c_int), value :: lvl       ! log level (NOTE: enum is of type int)
       type(c_ptr) :: sph
     end function
   end interface
@@ -131,7 +133,7 @@ program main
   end if
 
   workspace = c_malloc(sz)                      ! allocates workspace on the heap
-  c_spheres = c_init(workspace)                 ! initializes the sphere properties
+  c_spheres = c_init(workspace, 0)              ! initializes the sphere properties
   call c_f_pointer(c_spheres, spheres)          ! binds to the C spheres container
   call c_f_pointer(spheres % props, props)      ! binds to the sphere properties
   call c_f_pointer(props % x, x, [numel])       ! binds to the x positions of the spheres


### PR DESCRIPTION
COMMENTS:
the test code consists of a simulation without Brownian Dynamics

as time progresses the particles move away from each other to minimize the force between them

updates the test FORTRAN API in accordance to the changes done in the particles/sphere/type.h header

the code has been tested with GCC 11.4.0 and 13.2.0