### PR TITLE
updates Makefiles

### DIFF
--- a/src/particles/sphere/Makefile
+++ b/src/particles/sphere/Makefile
@@ -18,7 +18,7 @@ include make-inc
 
 all: $(SPHERE_O)
 
-$(SPHERE_O): $(SYSBOX_H) $(ARRAYS_H) $(SPHERE_H) $(SPHERE_C)
+$(SPHERE_O): $(HEADERS) $(SPHERE_C)
 	$(CC) $(INC) $(CCOPT) -c $(SPHERE_C) -o $(SPHERE_O)
 
 clean:

--- a/src/particles/sphere/make-inc
+++ b/src/particles/sphere/make-inc
@@ -17,9 +17,36 @@
 INC = -I../../../inc
 
 # headers
+FCONFG_H = ../../../inc/fconfig.h
+CONFIG_H = ../../../inc/config.h
+
+BDS_TYPES_H = ../../../inc/bds/types.h
+
+SYSBOX_PARAMS_H = ../../../inc/system/box/params.h
+SYSBOX_UTILS_H = ../../../inc/system/box/utils.h
 SYSBOX_H = ../../../inc/system/box.h
-SPHERE_H = ../../../inc/particles/sphere.h
+
+SYSTEM_PARAMS_H = ../../../inc/system/params.h
+SYSTEM_H = ../../../inc/system.h
+
 ARRAYS_H = ../../../inc/util/arrays.h
+
+RNDERR_H = ../../../inc/util/random/err.h
+RANDTP_H = ../../../inc/util/random/type.h
+RANDOM_H = ../../../inc/util/random.h
+
+UTILTP_H = ../../../inc/util/type.h
+UTIL_H = ../../../inc/util.h
+
+SPHERE_TYPE_H = ../../../inc/particles/sphere/type.h
+SPHERE_PARAMS_H = ../../../inc/particles/sphere/params.h
+SPHERE_UTILS_H = ../../../inc/particles/sphere/utils.h
+SPHERE_H = ../../../inc/particles/sphere.h
+
+HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(SYSBOX_PARAMS_H) $(SYSBOX_UTILS_H)\
+	  $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H) $(ARRAYS_H) $(RNDERR_H) $(RANDTP_H)\
+	  $(RANDOM_H) $(UTILTP_H) $(UTIL_H) $(SPHERE_TYPE_H) $(SPHERE_PARAMS_H)\
+	  $(SPHERE_UTILS_H) $(SPHERE_H)
 
 # sources
 SPHERE_C = sphere.c

--- a/src/system/box/Makefile
+++ b/src/system/box/Makefile
@@ -18,7 +18,7 @@ include make-inc
 
 all: $(BOX_O)
 
-$(BOX_O): $(SYSTEM_H) $(BOX_H) $(BOX_C)
+$(BOX_O): $(HEADERS) $(BOX_C)
 	$(CC) $(INC) $(CCOPT) -c $(BOX_C) -o $(BOX_O)
 
 clean:

--- a/src/system/box/make-inc
+++ b/src/system/box/make-inc
@@ -17,8 +17,20 @@
 INC = -I../../../inc
 
 # headers
+FCONFG_H = ../../../inc/fconfig.h
+CONFIG_H = ../../../inc/config.h
+
+BDS_TYPES_H = ../../../inc/bds/types.h
+
+SYSBOX_PARAMS_H = ../../../inc/system/box/params.h
+SYSBOX_UTILS_H = ../../../inc/system/box/utils.h
+SYSBOX_H = ../../../inc/system/box.h
+
+SYSTEM_PARAMS_H = ../../../inc/system/params.h
 SYSTEM_H = ../../../inc/system.h
-BOX_H = ../../../inc/system/box.h
+
+HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(SYSBOX_PARAMS_H) $(SYSBOX_UTILS_H)\
+	  $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H)
 
 # sources
 BOX_C = box.c

--- a/src/test/particles-sphere/Makefile
+++ b/src/test/particles-sphere/Makefile
@@ -27,7 +27,7 @@ $(FEST): $(FEST_O)
 $(TEST_O): $(DEPS_O) $(TEST_C)
 	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
 
-$(FEST_O): $(TEST_F)
+$(FEST_O): $(DEPS_O) $(TEST_F)
 	$(FC) $(INC) $(FCOPT) -c $(TEST_F) -o $(FEST_O)
 
 clean:

--- a/src/util/array/Makefile
+++ b/src/util/array/Makefile
@@ -18,7 +18,7 @@ include make-inc
 
 all: $(ARRAYS_O)
 
-$(ARRAYS_O): $(SYSTEM_H) $(ARRAYS_H) $(ARRAYS_C)
+$(ARRAYS_O): $(HEADERS) $(ARRAYS_C)
 	$(CC) $(INC) $(CCOPT) -c $(ARRAYS_C) -o $(ARRAYS_O)
 
 clean:

--- a/src/util/array/make-inc
+++ b/src/util/array/make-inc
@@ -17,8 +17,16 @@
 INC = -I../../../inc
 
 # headers
-SYSTEM_H = ../../../inc/system.h
+FCONFG_H = ../../../inc/fconfig.h
+CONFIG_H = ../../../inc/config.h
+
+BDS_TYPES_H = ../../../inc/bds/types.h
+
+SYSTEM_PARAMS_H = ../../../inc/system/params.h
+
 ARRAYS_H = ../../../inc/util/arrays.h
+
+HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(SYSTEM_PARAMS_H) $(ARRAYS_H)
 
 # sources
 ARRAYS_C = arrays.c

--- a/src/util/random/Makefile
+++ b/src/util/random/Makefile
@@ -18,7 +18,7 @@ include make-inc
 
 all: $(RANDOM_O)
 
-$(RANDOM_O): $(RANDOM_H) $(RANDOM_C)
+$(RANDOM_O): $(HEADERS) $(RANDOM_C)
 	$(CC) $(INC) $(CCOPT) -c $(RANDOM_C) -o $(RANDOM_O)
 
 clean:

--- a/src/util/random/make-inc
+++ b/src/util/random/make-inc
@@ -17,7 +17,11 @@
 INC = -I../../../inc
 
 # headers
+RNDERR_H = ../../../inc/util/random/err.h
+RANDTP_H = ../../../inc/util/random/type.h
 RANDOM_H = ../../../inc/util/random.h
+
+HEADERS = $(RNDERR_H) $(RANDTP_H) $(RANDOM_H)
 
 # sources
 RANDOM_C = random.c

--- a/src/util/type/Makefile
+++ b/src/util/type/Makefile
@@ -18,7 +18,7 @@ include make-inc
 
 all: $(TYPE_O)
 
-$(TYPE_O): $(TYPE_H) $(TYPE_C)
+$(TYPE_O): $(HEADERS) $(TYPE_C)
 	$(CC) $(INC) $(CCOPT) -c $(TYPE_C) -o $(TYPE_O)
 
 clean:

--- a/src/util/type/make-inc
+++ b/src/util/type/make-inc
@@ -17,7 +17,12 @@
 INC = -I../../../inc
 
 # headers
+RANDTP_H = ../../../inc/util/random/type.h
+RANDOM_H = ../../../inc/util/random.h
+
 TYPE_H = ../../../inc/util/type.h
+
+HEADERS = $(RANDTP_H) $(RANDOM_H) $(TYPE_H)
 
 # sources
 TYPE_C = type.c


### PR DESCRIPTION
COMMENTS:
fixes possible incomplete builds

for example, changing the number of particles requires the recompilation of the array utils because this parameter is hardcoded via MACROS

adds the headers that upon modification imply the recompilation of the implementation files in the respective Makefiles

this is not necessary for the tests themselves because any change to the implementation files already causes the tests to be rebuilt

got away with this because the project size is small so doing a `make clean && make' on the Linux terminal guarantees a complete build