### PR TITLE
dumps BDS params [clang] [FORTRAN]

### DIFF
--- a/src/particles/sphere/sphere.c
+++ b/src/particles/sphere/sphere.c
@@ -1115,6 +1115,28 @@ static int updater (sphere_t* spheres)
 }
 
 
+// dumps BDS parameters to a plain txt file (usually for and post-proccesing)
+static int info ()
+{
+  const char fname[] = "run/bds/data/params/params-bds.txt";
+  FILE* file = fopen(fname, "w");
+  if (file == NULL)
+  {
+    const char errmsg[] = "info(): IO ERROR with file %s: %s\n";
+    fprintf(stderr, errmsg, fname, strerror(errno));
+    return FAILURE;
+  }
+
+  fprintf(file, "LIMIT:       %.16e\n", LIMIT);
+  fprintf(file, "LENGTH:      %.16e\n", LENGTH);
+  fprintf(file, "TIME_STEP:   %.16e\n", TSTEP);
+  fprintf(file, "NUM_SPHERES: %lu\n",   NUMEL);
+
+  fclose(file);
+  return SUCCESS;
+}
+
+
 // logs some properties of interest such as the positions of the particles
 static int logger (const sphere_t* spheres, size_t const step)
 {
@@ -1272,6 +1294,19 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
     return NULL;
 #endif
   }
+
+
+  // attemps to dump BDS parameters to a plain text file as a runtime check
+  if (info() == FAILURE)
+  {
+    fprintf(stderr, "sphere-initializer(): ERROR\n");
+#if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
+    return nullptr;
+#else
+    return NULL;
+#endif
+  }
+
 
   // bindinds:
 

--- a/src/test/particles-sphere/test.f
+++ b/src/test/particles-sphere/test.f
@@ -189,6 +189,13 @@ contains
     end if
 
     ptr = c_init(spheres % workspace, 0)
+
+    if ( .not. c_associated(ptr) ) then
+      call c_free(spheres % workspace)
+      spheres % workspace = c_null_ptr
+      error stop "constructor(): ERROR"
+    end if
+
     call c_f_pointer(ptr, spheres % c_spheres)
     call c_f_procpointer(spheres % c_spheres % update, spheres % c_update)
 
@@ -286,6 +293,13 @@ program main
 
   workspace = c_malloc(sz)                      ! allocates workspace on the heap
   c_spheres = c_init(workspace, 0)              ! initializes the sphere properties
+
+  if ( .not. c_associated(c_spheres) ) then
+    call c_free(workspace)                      ! frees workspace from memory
+    workspace = c_null_ptr                      ! nullifies pointer to workspace
+    error stop "test(): ERROR"
+  end if
+
   call c_f_pointer(c_spheres, spheres)          ! binds to the C spheres container
   call c_f_pointer(spheres % props, props)      ! binds to the sphere properties
   call c_f_pointer(props % x, x, [numel])       ! binds to the x positions of the spheres


### PR DESCRIPTION
COMMENTS:
we shall use this for post-processing and video rendering

FORTRAN code aborts with error if there's an IO ERROR

valgrind reports no memory leaks even in the event of an IO ERROR