### PR TITLE
updates POV-RAY generator [Python]

### DIFF
--- a/scripts/render/genpovs.py
+++ b/scripts/render/genpovs.py
@@ -83,13 +83,14 @@ header = (
 )
 
 run = 'run/bds/data/positions/'
-out = 'run/bds/render/frames/'
+out = 'run/bds/render/frames/spheres-'
+pre = 'run/bds/data/positions/spheres-'
 # generates a povray file for each datafile (storing the particle positions) nested in run
 for datafile in glob('run/bds/data/positions/*.txt'):
 
   fname, ext = datafile.split('.')
-  _, fname = fname.split(run)
-  povfile = f'{out}{fname}.pov'
+  _, step = fname.split(pre)
+  povfile = f'{out}{int(step):032d}.pov'
   with open(povfile, 'w') as f:
 
     f.write(header)


### PR DESCRIPTION
COMMENTS:
updates the generator so that the names of the povray files have leading zeros

Note that the OBDS code does not add leading zeros to the data files (as the earlier version did)

This is useful when using `ffmpeg' to render the video from the frames via globbing:

	ffmpeg -pattern_type glob -i '*.png' video

String splitting is used because the names are simple enough so that we can extract the step-id without regular expressions regexs.