### PR TITLE
uses expected MACRO names for portability

### DIFF
--- a/src/particles/sphere/sphere.c
+++ b/src/particles/sphere/sphere.c
@@ -1233,8 +1233,10 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
   // compile-time sane checks:
 
 #if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
-  static_assert( __BYTE_ORDER == __LITTLE_ENDIAN );
-  static_assert( __FLOAT_WORD_ORDER == __LITTLE_ENDIAN );
+  static_assert(BYTE_ORDER == LITTLE_ENDIAN);
+#if defined(FLOAT_WORD_ORDER)
+  static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN);
+#endif
   static_assert( __OBDS_LOG_NUM_SPHERES__ >= 8LU );
   static_assert(sizeof(NUMEL) == 8);
   static_assert(sizeof(RADIUS) == 8);
@@ -1255,8 +1257,10 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
   static_assert(CONTACT == 2.0);
   static_assert(RADIUS == 1.0);
 #else
-  _Static_assert( __BYTE_ORDER == __LITTLE_ENDIAN );
-  _Static_assert( __FLOAT_WORD_ORDER == __LITTLE_ENDIAN );
+  _Static_assert(BYTE_ORDER == LITTLE_ENDIAN);
+#if defined(FLOAT_WORD_ORDER)
+  _Static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN);
+#endif
   _Static_assert( __OBDS_LOG_NUM_SPHERES__ >= 8LU );
   _Static_assert(sizeof(NUMEL) == 8);
   _Static_assert(sizeof(RADIUS) == 8);


### PR DESCRIPTION
COMMENTS:
OSX's machine/endian.h defines the MACROS in question without the leading underscores (GLIBC's endian.h does as well but I was not yet concerned about portability)

OSX's machine/endian.h does not define the FLOAT_WORD_ORDER MACRO so had to add code to check if it's actually defined to perform a successful compilation

OSX compiled OBDS code passes existing tests