### PR TITLE
portability fixes [clang]

### DIFF
--- a/inc/util/arrays.h
+++ b/inc/util/arrays.h
@@ -3,7 +3,7 @@
 
 #include "bds/types.h"
 
-void copy (const prop_t* restrict src, prop_t* restrict dst);
+void copy (const prop_t* __restrict__ src, prop_t* __restrict__ dst);
 void zeros (prop_t* x);
 void ones (prop_t* x);
 void iota (prop_t* x);

--- a/src/particles/sphere/sphere.c
+++ b/src/particles/sphere/sphere.c
@@ -85,7 +85,7 @@ static uint64_t nexp (uint64_t const x)
 // 		for non-interacting pairs
 
 
-static void inrange (const prop_t* restrict dist, prop_t* restrict bitmask)
+static void inrange (const prop_t* __restrict__ dist, prop_t* __restrict__ bitmask)
 {
   uint64_t* b = &bitmask[0].bin;
   const uint64_t* r = &dist[0].bin;
@@ -97,7 +97,9 @@ static void inrange (const prop_t* restrict dist, prop_t* restrict bitmask)
 
 
 // zeroes the x, y, and z components of the force
-static void zeroes (prop_t* restrict f_x, prop_t* restrict f_y, prop_t* restrict f_z)
+static void zeroes (prop_t* __restrict__ f_x,
+		    prop_t* __restrict__ f_y,
+		    prop_t* __restrict__ f_z)
 {
   zeros(f_x);
   zeros(f_y);
@@ -176,7 +178,9 @@ static double min (const prop_t* vectors)
 //              computation of the bitmask to the inrange method().
 
 
-static void SLJ (prop_t* restrict dist, prop_t* restrict force, prop_t* restrict  bitmask)
+static void SLJ (prop_t* __restrict__ dist,
+		 prop_t* __restrict__ force,
+		 prop_t* __restrict__  bitmask)
 {
 
   // scales the interparticle distance (as required by the inrange() method):
@@ -271,15 +275,15 @@ static void pairs (size_t const i,
 		   double const offset_x,
 		   double const offset_y,
 		   double const offset_z,
-		   const prop_t* restrict p_x,
-		   const prop_t* restrict p_y,
-		   const prop_t* restrict p_z,
-		   prop_t* restrict p_F_x,
-		   prop_t* restrict p_F_y,
-		   prop_t* restrict p_F_z,
-		   prop_t* restrict p_f,
-		   prop_t* restrict p_d,
-		   prop_t* restrict p_bitmask)
+		   const prop_t* __restrict__ p_x,
+		   const prop_t* __restrict__ p_y,
+		   const prop_t* __restrict__ p_z,
+		   prop_t* __restrict__ p_F_x,
+		   prop_t* __restrict__ p_F_y,
+		   prop_t* __restrict__ p_F_z,
+		   prop_t* __restrict__ p_f,
+		   prop_t* __restrict__ p_d,
+		   prop_t* __restrict__ p_bitmask)
 {
   // computes the interparticle distance between the ith and jth particles:
 
@@ -389,15 +393,15 @@ static void pairs (size_t const i,
 // mask		array of size NUMEL used for storing intermediate results
 
 
-static void resultants (const prop_t* restrict x,
-		        const prop_t* restrict y,
-		        const prop_t* restrict z,
-		        prop_t* restrict F_x,
-		        prop_t* restrict F_y,
-		        prop_t* restrict F_z,
-		        prop_t* restrict tmp,
-		        prop_t* restrict temp,
-		        prop_t* restrict mask)
+static void resultants (const prop_t* __restrict__ x,
+		        const prop_t* __restrict__ y,
+		        const prop_t* __restrict__ z,
+		        prop_t* __restrict__ F_x,
+		        prop_t* __restrict__ F_y,
+		        prop_t* __restrict__ F_z,
+		        prop_t* __restrict__ tmp,
+		        prop_t* __restrict__ temp,
+		        prop_t* __restrict__ mask)
 {
   for (size_t i = 0; i != NUMEL; ++i)
   {
@@ -636,10 +640,10 @@ static void resultants (const prop_t* restrict x,
 
 // clamps forces larger than CLAMP to CLAMP; in other words, this method makes sure that
 // there is no force (component) larger than the value represented by the CLAMP MACRO.
-static void clamp (prop_t* restrict p_force,
-		   prop_t* restrict p_tmp,
-		   prop_t* restrict p_temp,
-		   prop_t* restrict p_bitmask)
+static void clamp (prop_t* __restrict__ p_force,
+		   prop_t* __restrict__ p_tmp,
+		   prop_t* __restrict__ p_temp,
+		   prop_t* __restrict__ p_bitmask)
 {
   double* temp = &p_temp[0].data;
   double* force = &p_force[0].data;
@@ -684,12 +688,12 @@ static void clamp (prop_t* restrict p_force,
 
 
 // clamps the x, y, and z components of the force
-static void clamps (prop_t* restrict f_x,
-		    prop_t* restrict f_y,
-		    prop_t* restrict f_z,
-		    prop_t* restrict tmp,
-		    prop_t* restrict temp,
-		    prop_t* restrict bitmask)
+static void clamps (prop_t* __restrict__ f_x,
+		    prop_t* __restrict__ f_y,
+		    prop_t* __restrict__ f_z,
+		    prop_t* __restrict__ tmp,
+		    prop_t* __restrict__ temp,
+		    prop_t* __restrict__ bitmask)
 {
   clamp(f_x, tmp, temp, bitmask);
   clamp(f_y, tmp, temp, bitmask);
@@ -749,7 +753,7 @@ static int stochastic_forces (random_t* random, prop_t* f_x, prop_t* f_y, prop_t
 
 
 // shifts the particles along the x, y, or z axis due to deterministic force effects
-static void shift (prop_t* restrict prop_x, const prop_t* restrict prop_F_x)
+static void shift (prop_t* __restrict__ prop_x, const prop_t* __restrict__ prop_F_x)
 {
   double const dt = TSTEP;
   double* x = &prop_x[0].data;
@@ -761,7 +765,8 @@ static void shift (prop_t* restrict prop_x, const prop_t* restrict prop_F_x)
 }
 
 
-static void stochastic_shift (prop_t* restrict prop_x, const prop_t* restrict prop_F_x)
+static void stochastic_shift (prop_t* __restrict__ prop_x,
+			      const prop_t* __restrict__ prop_F_x)
 {
   double* x = &prop_x[0].data;
   const double* F_x = &prop_F_x[0].data;
@@ -774,7 +779,8 @@ static void stochastic_shift (prop_t* restrict prop_x, const prop_t* restrict pr
 
 
 // stores the change in the Euler angle `x'
-static void stochastic_rotation (prop_t* restrict prop_x, const prop_t* restrict prop_T_x)
+static void stochastic_rotation (prop_t* __restrict__ prop_x,
+				 const prop_t* __restrict__ prop_T_x)
 {
   double* x = &prop_x[0].data;
   const double* T_x = &prop_T_x[0].data;
@@ -787,12 +793,12 @@ static void stochastic_rotation (prop_t* restrict prop_x, const prop_t* restrict
 
 
 // shifts the particles along the axes owing to the net deterministic forces
-static void shifts (prop_t* restrict x,
-		    prop_t* restrict y,
-		    prop_t* restrict z,
-		    const prop_t* restrict f_x,
-		    const prop_t* restrict f_y,
-		    const prop_t* restrict f_z)
+static void shifts (prop_t* __restrict__ x,
+		    prop_t* __restrict__ y,
+		    prop_t* __restrict__ z,
+		    const prop_t* __restrict__ f_x,
+		    const prop_t* __restrict__ f_y,
+		    const prop_t* __restrict__ f_z)
 {
   shift(x, f_x);
   shift(y, f_y);
@@ -800,12 +806,12 @@ static void shifts (prop_t* restrict x,
 }
 
 
-static void stochastic_shifts (prop_t* restrict x,
-			       prop_t* restrict y,
-			       prop_t* restrict z,
-			       const prop_t* restrict f_x,
-			       const prop_t* restrict f_y,
-			       const prop_t* restrict f_z)
+static void stochastic_shifts (prop_t* __restrict__ x,
+			       prop_t* __restrict__ y,
+			       prop_t* __restrict__ z,
+			       const prop_t* __restrict__ f_x,
+			       const prop_t* __restrict__ f_y,
+			       const prop_t* __restrict__ f_z)
 {
   stochastic_shift(x, f_x);
   stochastic_shift(y, f_y);
@@ -824,15 +830,15 @@ static void stochastic_shifts (prop_t* restrict x,
 // d_x, d_y, d_z	components of the current director (at time t)
 
 
-static void kinematics (prop_t* restrict p_x,
-			prop_t* restrict p_y,
-			prop_t* restrict p_z,
-			const prop_t* restrict p_dx,
-			const prop_t* restrict p_dy,
-			const prop_t* restrict p_dz,
-			const prop_t* restrict p_d_x,
-			const prop_t* restrict p_d_y,
-			const prop_t* restrict p_d_z)
+static void kinematics (prop_t* __restrict__ p_x,
+			prop_t* __restrict__ p_y,
+			prop_t* __restrict__ p_z,
+			const prop_t* __restrict__ p_dx,
+			const prop_t* __restrict__ p_dy,
+			const prop_t* __restrict__ p_dz,
+			const prop_t* __restrict__ p_d_x,
+			const prop_t* __restrict__ p_d_y,
+			const prop_t* __restrict__ p_d_z)
 
 {
   double* x = &p_x[0].data;
@@ -854,11 +860,11 @@ static void kinematics (prop_t* restrict p_x,
 
 
 // normalizes the vector (makes unit vector) whose components are x, y, and z
-static void normalize (prop_t* restrict p_x,
-		       prop_t* restrict p_y,
-		       prop_t* restrict p_z,
-		       prop_t* restrict p_v,
-		       prop_t* restrict p_t)
+static void normalize (prop_t* __restrict__ p_x,
+		       prop_t* __restrict__ p_y,
+		       prop_t* __restrict__ p_z,
+		       prop_t* __restrict__ p_v,
+		       prop_t* __restrict__ p_t)
 {
   double* x = &p_x[0].data;
   double* y = &p_y[0].data;
@@ -898,7 +904,8 @@ static void normalize (prop_t* restrict p_x,
 
 
 // updates the Euler angle `x' with the angular displacement stored in `_dx'
-static void update_Euler_angle (prop_t* restrict prop_x, const prop_t* restrict prop_dx)
+static void update_Euler_angle (prop_t* __restrict__ prop_x,
+				const prop_t* __restrict__ prop_dx)
 {
   double* x = &prop_x[0].data;
   const double* _dx = &prop_dx[0].data;
@@ -927,22 +934,22 @@ static void update_Euler_angle (prop_t* restrict prop_x, const prop_t* restrict 
 // t_x, t_y, t_z	components of the torque
 
 
-static void stochastic_rotations (prop_t* restrict a_x,
-				  prop_t* restrict a_y,
-				  prop_t* restrict a_z,
-				  prop_t* restrict d_x,
-				  prop_t* restrict d_y,
-				  prop_t* restrict d_z,
-				  prop_t* restrict x,
-				  prop_t* restrict y,
-				  prop_t* restrict z,
-				  prop_t* restrict _dx,
-				  prop_t* restrict _dy,
-				  prop_t* restrict _dz,
-				  prop_t* restrict tmp,
-				  const prop_t* restrict t_x,
-				  const prop_t* restrict t_y,
-				  const prop_t* restrict t_z)
+static void stochastic_rotations (prop_t* __restrict__ a_x,
+				  prop_t* __restrict__ a_y,
+				  prop_t* __restrict__ a_z,
+				  prop_t* __restrict__ d_x,
+				  prop_t* __restrict__ d_y,
+				  prop_t* __restrict__ d_z,
+				  prop_t* __restrict__ x,
+				  prop_t* __restrict__ y,
+				  prop_t* __restrict__ z,
+				  prop_t* __restrict__ _dx,
+				  prop_t* __restrict__ _dy,
+				  prop_t* __restrict__ _dz,
+				  prop_t* __restrict__ tmp,
+				  const prop_t* __restrict__ t_x,
+				  const prop_t* __restrict__ t_y,
+				  const prop_t* __restrict__ t_z)
 {
   // updates the Euler angles:
 
@@ -968,7 +975,9 @@ static void stochastic_rotations (prop_t* restrict a_x,
 
 
 // places the spheres in a grid (or lattice) like structure for system initialization
-static void grid (prop_t* restrict xprop, prop_t* restrict yprop, prop_t* restrict zprop)
+static void grid (prop_t* __restrict__ xprop,
+		  prop_t* __restrict__ yprop,
+		  prop_t* __restrict__ zprop)
 {
   // gets the number of spheres (at contact) that can be fitted along any dimension:
 
@@ -1020,12 +1029,12 @@ static void grid (prop_t* restrict xprop, prop_t* restrict yprop, prop_t* restri
 }
 
 
-static void pbcs (prop_t* restrict x,
-		  prop_t* restrict y,
-		  prop_t* restrict z,
-		  prop_t* restrict tmp,
-		  prop_t* restrict temp,
-		  prop_t* restrict mask)
+static void pbcs (prop_t* __restrict__ x,
+		  prop_t* __restrict__ y,
+		  prop_t* __restrict__ z,
+		  prop_t* __restrict__ tmp,
+		  prop_t* __restrict__ temp,
+		  prop_t* __restrict__ mask)
 {
   pbc(x, tmp, temp);
   pbc(y, tmp, temp);
@@ -1034,7 +1043,7 @@ static void pbcs (prop_t* restrict x,
 
 
 // sums `src' and `dst' vectors (elementwise), stores the result in `dst'
-static void vsum (prop_t* restrict dest, const prop_t* restrict source)
+static void vsum (prop_t* __restrict__ dest, const prop_t* __restrict__ source)
 {
   double* dst = &dest[0].data;
   const double* src = &source[0].data;
@@ -1257,32 +1266,65 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
   static_assert(CONTACT == 2.0);
   static_assert(RADIUS == 1.0);
 #else
-  _Static_assert(BYTE_ORDER == LITTLE_ENDIAN);
+  _Static_assert(BYTE_ORDER == LITTLE_ENDIAN, "expects little-endian byte-order");
 #if defined(FLOAT_WORD_ORDER)
-  _Static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN);
+  _Static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN, "expects little-endian byte-order");
 #endif
-  _Static_assert( __OBDS_LOG_NUM_SPHERES__ >= 8LU );
-  _Static_assert(sizeof(NUMEL) == 8);
-  _Static_assert(sizeof(RADIUS) == 8);
-  _Static_assert(sizeof(CONTACT) == 8);
-  _Static_assert(sizeof(OBDS_Sphere_t) == 256);
-  _Static_assert(sizeof(size_t) == sizeof(uint64_t));
-  _Static_assert(sizeof(sphere_t) == 32);
-  _Static_assert(sizeof(prop_t) == 8);
-  _Static_assert(sizeof(random_t) == 16);
-  _Static_assert(sizeof(generator_t) == 32);
-  _Static_assert(sizeof(uint64_t) == 8);
-  _Static_assert(sizeof(double) == 8);
-  _Static_assert(NUMEL != 0);
-  _Static_assert(NUMEL % 2 == 0);
-  _Static_assert(SIZE_MAX == UINT64_MAX);
-  _Static_assert(NUMEL <= 0x7fffffffffffffff);
-  _Static_assert( SIZED * (RADIUS * RADIUS * RADIUS) < (LIMIT * LIMIT * LIMIT) );
-  _Static_assert(CONTACT == 2.0);
-  _Static_assert(RADIUS == 1.0);
+  _Static_assert( __OBDS_LOG_NUM_SPHERES__ >= 8LU, "expects log2(NUM_SPHERES) >= 8" );
+  _Static_assert(sizeof(NUMEL) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(RADIUS) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(CONTACT) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(OBDS_Sphere_t) == 256, "expects 256 bytes");
+  _Static_assert(sizeof(size_t) == sizeof(uint64_t), "expects equal size");
+  _Static_assert(sizeof(sphere_t) == 32, "expects 32 bytes");
+  _Static_assert(sizeof(prop_t) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(random_t) == 16, "expects 16 bytes");
+  _Static_assert(sizeof(generator_t) == 32, "expects 32 bytes");
+  _Static_assert(sizeof(uint64_t) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(double) == 8, "expects 8 bytes");
+  _Static_assert(NUMEL != 0, "expects non-zero value for NUM_SPHERES");
+  _Static_assert(NUMEL % 2 == 0, "expects NUM_SPHERES to be even");
+  _Static_assert(SIZE_MAX == UINT64_MAX, "expects equal range");
+  _Static_assert(NUMEL <= 0x7fffffffffffffff, "expects fewer NUM_SPHERES");
 #endif
 
   // runtime sane checks:
+
+  if (RADIUS != 1.0)
+  {
+    errno = EINVAL;
+    char err[] = "sphere-initializer() expects unit spheres: %s\n";
+    fprintf(stderr, err, strerror(errno));
+#if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
+    return nullptr;
+#else
+    return NULL;
+#endif
+  }
+
+  if (CONTACT != 2.0)
+  {
+    errno = EINVAL;
+    char err[] = "sphere-initializer() expects unit spheres: %s\n";
+    fprintf(stderr, err, strerror(errno));
+#if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
+    return nullptr;
+#else
+    return NULL;
+#endif
+  }
+
+  if ( SIZED * (RADIUS * RADIUS * RADIUS) >= (LIMIT * LIMIT * LIMIT) )
+  {
+    errno = EINVAL;
+    char err[] = "sphere-initializer() expects smaller volume fractions: %s\n";
+    fprintf(stderr, err, strerror(errno));
+#if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
+    return nullptr;
+#else
+    return NULL;
+#endif
+  }
 
   prop_t const dt = { .data = TSTEP };
   uint64_t const bin = dt.bin;
@@ -1462,6 +1504,9 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
 
   grid(x, y, z);
 
+  extern int util_random_initializer(random_t*, enum PRNG);
+  iPRNG_t const irandom = { .initializer = util_random_initializer };
+  util_t const util = { .random = irandom };
   if (util.random.initializer(spheres -> prng, NRAND) == FAILURE)
   {
     fprintf(stderr, "particles.sphere.initializer(): PRNG ERROR\n");

--- a/src/system/box/box.c
+++ b/src/system/box/box.c
@@ -59,7 +59,7 @@ static uint64_t unlimited (uint64_t const x)
 
 
 // masks particles beyond the system limits with a binary pattern of ones, otherwise zeros
-static void mask (const prop_t* restrict x, prop_t* restrict bitmask)
+static void mask (const prop_t* __restrict__ x, prop_t* __restrict__ bitmask)
 {
   uint64_t* b = &bitmask[0].bin;
   const uint64_t* fp = &x[0].bin;
@@ -95,9 +95,9 @@ static void rescale (prop_t* x)
 
 
 // sets the offset on the particles according to the bitmask and their positions (signbit)
-static void offset (const prop_t* restrict x,
-		    const prop_t* restrict bitmask,
-		    prop_t* restrict offset)
+static void offset (const prop_t* __restrict__ x,
+		    const prop_t* __restrict__ bitmask,
+		    prop_t* __restrict__ offset)
 {
   double const length = 2.0;
   uint64_t* o = &offset[0].bin;
@@ -113,7 +113,7 @@ static void offset (const prop_t* restrict x,
 
 
 // shifts x, y, or z-axis coordinates by the offset
-static void shift (prop_t* restrict x, const prop_t* restrict offset)
+static void shift (prop_t* __restrict__ x, const prop_t* __restrict__ offset)
 {
   double* data = &x[0].data;
   const double* o = &offset[0].data;
@@ -125,7 +125,9 @@ static void shift (prop_t* restrict x, const prop_t* restrict offset)
 
 
 // applies periodic boundary conditions to the particles
-void pbc (prop_t* restrict x, prop_t* restrict distance, prop_t* restrict bitmask)
+void pbc (prop_t* __restrict__ x,
+	  prop_t* __restrict__ distance,
+	  prop_t* __restrict__ bitmask)
 {
   // applies required pre-scaling:
 

--- a/src/test/particles-sphere/make-inc
+++ b/src/test/particles-sphere/make-inc
@@ -26,7 +26,7 @@ ARRAYS_O = ../../util/array/arrays.o
 RANDOM_O = ../../util/random/random.o
 UTILTP_O = ../../util/type/type.o
 SPHERE_O = ../../particles/sphere/sphere.o
-DEPS_O = $(SYSBOX_O) $(ARRAYS_O) $(RANDOM_O) $(UTILTP_O) $(SPHERE_O)
+DEPS_O = $(SYSBOX_O) $(ARRAYS_O) $(RANDOM_O) $(SPHERE_O)
 TEST_O = test.o
 FEST_O = fest.o
 

--- a/src/test/particles-sphere/test.c
+++ b/src/test/particles-sphere/test.c
@@ -135,9 +135,9 @@ void test (void)
 #else
 void test (void)
 {
-  _Static_assert(sizeof(sphere_t) == 32);
-  _Static_assert(sizeof(OBDS_Sphere_t) == 256);
-  _Static_assert(sizeof(prop_t) == 8);
+  _Static_assert(sizeof(sphere_t) == 32, "expects 32 bytes");
+  _Static_assert(sizeof(OBDS_Sphere_t) == 256, "expects 256 bytes");
+  _Static_assert(sizeof(prop_t) == 8, "expects 8 bytes");
   size_t const sz = sizeof(sphere_t) +
 		    sizeof(OBDS_Sphere_t) +
 		    PROPS * sizeof(prop_t) +
@@ -349,9 +349,9 @@ void test1 (void)
 #else
 void test1 (void)
 {
-  _Static_assert(sizeof(sphere_t) == 32);
-  _Static_assert(sizeof(OBDS_Sphere_t) == 256);
-  _Static_assert(sizeof(prop_t) == 8);
+  _Static_assert(sizeof(sphere_t) == 32, "expects 32 bytes");
+  _Static_assert(sizeof(OBDS_Sphere_t) == 256, "expects 256 bytes");
+  _Static_assert(sizeof(prop_t) == 8, "expects 8 bytes");
   size_t const sz = sizeof(sphere_t) +
 		    sizeof(OBDS_Sphere_t) +
 		    PROPS * sizeof(prop_t) +

--- a/src/test/random/Makefile
+++ b/src/test/random/Makefile
@@ -19,9 +19,9 @@ include make-inc
 all: $(TEST)
 
 $(TEST): $(TEST_O)
-	$(CC) $(INC) $(CCOPT) $(TYPE_O) $(RANDOM_O) $(TEST_O) -o $(TEST) $(LIBS)
+	$(CC) $(INC) $(CCOPT) $(RANDOM_O) $(TEST_O) -o $(TEST) $(LIBS)
 
-$(TEST_O): $(RANDOM_H) $(RANDOM_O) $(TYPE_O) $(TEST_C)
+$(TEST_O): $(RANDOM_H) $(RANDOM_O) $(TEST_C)
 	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
 
 clean:

--- a/src/test/random/make-inc
+++ b/src/test/random/make-inc
@@ -24,7 +24,6 @@ TYPE_H = ../../../inc/util/type.h
 TEST_C = test.c
 
 # objects
-TYPE_O = ../../util/type/type.o
 RANDOM_O = ../../util/random/random.o
 TEST_O = test.o
 

--- a/src/test/random/test.c
+++ b/src/test/random/test.c
@@ -20,8 +20,6 @@
 #define TOL 0.001953125
 #define LOG false
 
-extern struct util const util;
-
 void test();
 
 int main ()
@@ -65,11 +63,11 @@ void test ()
   static_assert(sizeof(double) == 8);
   static_assert(SIZE == 64);
 #else
-  _Static_assert(sizeof(struct random) == 16);
-  _Static_assert(sizeof(struct generator) == 32);
-  _Static_assert(sizeof(uint64_t) == 8);
-  _Static_assert(sizeof(double) == 8);
-  _Static_assert(SIZE == 64);
+  _Static_assert(sizeof(struct random) == 16, "expects 16 bytes");
+  _Static_assert(sizeof(struct generator) == 32, "expects 32 bytes");
+  _Static_assert(sizeof(uint64_t) == 8, "expects 8 bytes");
+  _Static_assert(sizeof(double) == 8, "expects 8 bytes");
+  _Static_assert(SIZE == 64, "expects 64 bytes");
 #endif
 
 #if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
@@ -106,6 +104,9 @@ void test ()
   random -> generator -> state = (uint64_t*) iter;
   iter += sizeof(uint64_t);
 
+  extern int util_random_initializer(random_t*, enum PRNG);
+  iPRNG_t const irandom = { .initializer = util_random_initializer };
+  util_t const util = { .random = irandom };
   int const stat = util.random.initializer(random, NRAND);
   if (stat != 0)
   {

--- a/src/util/array/arrays.c
+++ b/src/util/array/arrays.c
@@ -4,7 +4,7 @@
 
 #define NUMEL ( (size_t) __OBDS_NUM_PARTICLES__ )
 
-void copy (const prop_t* restrict source, prop_t* restrict dest)
+void copy (const prop_t* __restrict__ source, prop_t* __restrict__ dest)
 {
   double* dst = &dest[0].data;
   const double* src = &source[0].data;

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -30,7 +30,7 @@ static uint32_t xor ()	// XORs the current time and the process ID for seeding t
 #if ( ( __GNUC__ > 12 ) && (__STDC_VERSION__ > STDC17 ) )
   static_assert(sizeof(time_t) == 8);
 #else
-  _Static_assert(sizeof(time_t) == 8);
+  _Static_assert(sizeof(time_t) == 8, "xor() expects `time_t' to be 8 bytes");
 #endif
   // if the underlying type of `time_t' is 64-bits, then use both the low and high bits
   time_t const t = time(NULL);
@@ -54,7 +54,8 @@ static uint32_t genseed () // generates seed by fetching /dev/urandom or fallsba
 #if ( ( __GNUC__ > 12 ) && (__STDC_VERSION__ > STDC17 ) )
   static_assert(sizeof(uint32_t) == sizeof(unsigned int));
 #else
-  _Static_assert(sizeof(uint32_t) == sizeof(unsigned int));
+  _Static_assert(sizeof(uint32_t) == sizeof(unsigned int),
+		 "genseed() expects 4 bytes size");
 #endif
   uint32_t prn = 0xffffffff;
   if (getrandom(&prn, sizeof(uint32_t), GRND_NONBLOCK) == -1)
@@ -72,7 +73,8 @@ static uint32_t genseed ()
 #if ( ( __GNUC__ > 12 ) && (__STDC_VERSION__ > STDC17 ) )
   static_assert(sizeof(uint32_t) == sizeof(unsigned int));
 #else
-  _Static_assert(sizeof(uint32_t) == sizeof(unsigned int));
+  _Static_assert(sizeof(uint32_t) == sizeof(unsigned int),
+		 "genseed() expects 4 bytes size");
 #endif
 
   int devurand = open("/dev/urandom", O_RDONLY);
@@ -105,7 +107,7 @@ static int seeder (generator_t* generator)
 #if ( ( __GNUC__ > 12 ) && (__STDC_VERSION__ > STDC17 ) )
   static_assert(sizeof(int) == 4);
 #else
-  _Static_assert(sizeof(int) == 4);
+  _Static_assert(sizeof(int) == 4, "seeder() expects `int's of 4 bytes");
 #endif
   uint64_t const seed = genseed();
   if ( (seed == 0) || (seed & 0x0000000000000001) )

--- a/src/util/type/type.c
+++ b/src/util/type/type.c
@@ -1,14 +1,14 @@
 #include "util/type.h"
 
-extern int util_random_initializer(random_t*, enum PRNG);
-
-static iPRNG_t const random = {
-  .initializer = util_random_initializer
-};
-
-util_t const util = {
-  .random = random
-};
+//extern int util_random_initializer(random_t*, enum PRNG);
+//
+//static iPRNG_t const random = {
+//  .initializer = util_random_initializer
+//};
+//
+//util_t const util = {
+//  .random = random
+//};
 
 /*
 


### PR DESCRIPTION
COMMENTS:
These changes make it possible to compile the OBDS code with the Intel Compilers icc and ifort (2021):

- provides messages for static assertions
- no floating-point types in static assertions
- replaces keyword `restrict' with __restrict__
- comments out code in util/type.c (unmet constant expression requirements)

OBDS code passes existing tests