### PR TITLE
writes particle data to tempfiles [clang]

### DIFF
--- a/src/test/particles-sphere/test.c
+++ b/src/test/particles-sphere/test.c
@@ -65,6 +65,14 @@ void test (void)
     return;
   }
 
+  if (spheres -> log(spheres, 0) == IOERR)
+  {
+    free(workspace);
+    workspace = nullptr;
+    fprintf(stderr, "test() ERROR\n");
+    return;
+  }
+
   double* x = &(spheres -> props -> x -> data);
   for (size_t i = 0; i != NUMEL; ++i)
   {
@@ -163,6 +171,13 @@ void test (void)
     return;
   }
 
+  if (spheres -> log(spheres, 0) == IOERR)
+  {
+    free(workspace);
+    workspace = NULL;
+    fprintf(stderr, "test() ERROR\n");
+    return;
+  }
 
   double* x = &(spheres -> props -> x -> data);
   for (size_t i = 0; i != NUMEL; ++i)


### PR DESCRIPTION
COMMENTS:
Writes particle data to a tempfile and if all goes well (no IO ERRORS) then the file is renamed.

We don't want to process the data of a BDS run if there are temp files lingering around.

Another use for this is self-checkpointing. If we attempt to restore a simulation from an incomplete data file (due to some interruption of sorts) the code would fail. But if instead, we use temporaries we know that (it is highly unlikely) for the data in the txt file to be incomplete (or corrupted). This is because the IO is done on the tmp file and we rename it only after we are done with it.

We don't need to close the file descriptor to the temporary file because fclose() already does that for us.