### PR TITLE
adds OBDS MACROS [clang]

### DIFF
--- a/inc/bds/params.h
+++ b/inc/bds/params.h
@@ -1,0 +1,29 @@
+#ifndef GUARD_OPENBDS_BDS_PARAMS_H
+#define GUARD_OPENBDS_BDS_PARAMS_H
+
+#define __OBDS_SUCCESS__ ( (int) 0x00000000 )
+#define __OBDS_FAILURE__ ( (int) 0xffffffff )
+
+#endif
+
+/*
+
+OpenBDS							September 26, 2023
+
+source: bds/params.h
+author: @misael-diaz
+
+Synopsis:
+Defines OpenBDS Parameter MACROS.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/src/io/logger/logger.c
+++ b/src/io/logger/logger.c
@@ -6,10 +6,11 @@
 #include <errno.h>
 
 #include "bds/types.h"
+#include "bds/params.h"
 #include "system/params.h"
 
-#define SUCCESS ( (int) 0x00000000 )
-#define FAILURE ( (int) 0xffffffff )
+#define SUCCESS ( (int) ( __OBDS_SUCCESS__ ) )
+#define FAILURE ( (int) ( __OBDS_FAILURE__ ) )
 #define NUMEL ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
 
 // logs the particle properties (position, orientation, id, etc.) to a plain text file

--- a/src/io/logger/make-inc
+++ b/src/io/logger/make-inc
@@ -18,10 +18,11 @@ INC = -I../../../inc
 
 # headers
 BDS_TYPES_H = ../../../inc/bds/types.h
+BDS_PARAMS_H = ../../../inc/bds/params.h
 SYSTEM_PARAMS_H = ../../../inc/system/params.h
 LOGGER_H = ../../../inc/io/logger.h
 
-HEADERS = $(BDS_TYPES_H) $(SYSTEM_PARAMS_H) $(LOGGER_H)
+HEADERS = $(BDS_TYPES_H) $(BDS_PARAMS_H) $(SYSTEM_PARAMS_H) $(LOGGER_H)
 
 # sources
 LOGGER_C = logger.c

--- a/src/particles/sphere/make-inc
+++ b/src/particles/sphere/make-inc
@@ -21,6 +21,7 @@ FCONFG_H = ../../../inc/fconfig.h
 CONFIG_H = ../../../inc/config.h
 
 BDS_TYPES_H = ../../../inc/bds/types.h
+BDS_PARAMS_H = ../../../inc/bds/params.h
 
 SYSBOX_PARAMS_H = ../../../inc/system/box/params.h
 SYSBOX_UTILS_H = ../../../inc/system/box/utils.h
@@ -43,10 +44,10 @@ SPHERE_PARAMS_H = ../../../inc/particles/sphere/params.h
 SPHERE_UTILS_H = ../../../inc/particles/sphere/utils.h
 SPHERE_H = ../../../inc/particles/sphere.h
 
-HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(SYSBOX_PARAMS_H) $(SYSBOX_UTILS_H)\
-	  $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H) $(ARRAYS_H) $(RNDERR_H) $(RANDTP_H)\
-	  $(RANDOM_H) $(UTILTP_H) $(UTIL_H) $(SPHERE_TYPE_H) $(SPHERE_PARAMS_H)\
-	  $(SPHERE_UTILS_H) $(SPHERE_H)
+HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(BDS_PARAMS_H) $(SYSBOX_PARAMS_H)\
+	  $(SYSBOX_UTILS_H) $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H) $(ARRAYS_H)\
+	  $(RNDERR_H) $(RANDTP_H) $(RANDOM_H) $(UTILTP_H) $(UTIL_H) $(SPHERE_TYPE_H)\
+	  $(SPHERE_PARAMS_H) $(SPHERE_UTILS_H) $(SPHERE_H)
 
 # sources
 SPHERE_C = sphere.c

--- a/src/particles/sphere/sphere.c
+++ b/src/particles/sphere/sphere.c
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "io/logger.h"
+#include "bds/params.h"
 #include "system/box.h"
 #include "particles/sphere/params.h"
 #include "particles/sphere/type.h"
@@ -14,8 +15,8 @@
 #include "util/type.h"
 
 #define STDC17 201710L
-#define SUCCESS ( (int) 0x00000000 )
-#define FAILURE ( (int) 0xffffffff )
+#define SUCCESS ( (int) ( __OBDS_SUCCESS__ ) )
+#define FAILURE ( (int) ( __OBDS_FAILURE__ ) )
 #define LIMIT ( (double) ( __OBDS_LIMIT__ ) )
 #define LENGTH ( (double) ( __OBDS_LENGTH__ ) )
 #define SIZED ( (double) ( __OBDS_NUM_SPHERES__ ) )

--- a/src/util/random/make-inc
+++ b/src/util/random/make-inc
@@ -17,11 +17,12 @@
 INC = -I../../../inc
 
 # headers
+BDSPRM_H = ../../../inc/bds/params.h
 RNDERR_H = ../../../inc/util/random/err.h
 RANDTP_H = ../../../inc/util/random/type.h
 RANDOM_H = ../../../inc/util/random.h
 
-HEADERS = $(RNDERR_H) $(RANDTP_H) $(RANDOM_H)
+HEADERS = $(BDSPRM_H) $(RNDERR_H) $(RANDTP_H) $(RANDOM_H)
 
 # sources
 RANDOM_C = random.c

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -12,11 +12,12 @@
 #include <time.h>	// provides system time(), see man time(2)
 #include <math.h>	// for generating normally distributed pseudo-random numbers
 
+#include "bds/params.h"
 #include "util/random.h"
 
 #define STDC17 201710L
-#define FAILURE ( (int) 0xffffffff )
-#define SUCCESS ( (int) 0x00000000 )
+#define FAILURE ( (int) ( __OBDS_FAILURE__ ) )
+#define SUCCESS ( (int) ( __OBDS_SUCCESS__ ) )
 #define MSBMASK ( (int64_t) 0x8000000000000000 )
 #define PERIOD ( (uint64_t) 0xffffffffffffffff )
 #define SCALING ( 1.0 / ( (double) MSBMASK ) )


### PR DESCRIPTION
COMMENTS:
these OBDS MACROS are used to check the status of whatever operation

initially the source files used these internally but now that the code is more integrated it makes more sense to use `global' MACROS (sharing the same purpose) to make the code easier to maintain

code compiles and executes as usual