### PR TITLE
adds variadic translating particle method [clang]

### DIFF
--- a/inc/particle/params.h
+++ b/inc/particle/params.h
@@ -1,0 +1,52 @@
+#ifndef GUARD_OPENBDS_PARTICLE_PARAMS_H
+#define GUARD_OPENBDS_PARTICLE_PARAMS_H
+
+#include "system/params.h"
+
+/* stands for the sqrt(2) */
+#define __OBDS_SQRT_OF_TWO__ 1.4142135623730951
+
+/* stands for the sqrt(3/2) */
+#define __OBDS_SQRT_OF_THREE_HALVES__ 1.2247448713915890
+
+/* ``effective'' translational mobility of a hydrodynamically isotropic particle under the
+ * action of Brownian (or stochastic) forces */
+#define __OBDS_ISOTROPIC_LINEAR_BROWNIAN_MOBILITY__ (\
+	( (double) ( __OBDS_SQRT_OF_TWO__ ) ) *\
+	( (double) ( __OBDS_SQRT_TIME_STEP__ ) )\
+)
+
+/* ``effective'' rotational mobility of a hydrodynamically isotropic particle under the
+ * action of Brownian (or stochastic) torques */
+#define __OBDS_ISOTROPIC_ANGULAR_BROWNIAN_MOBILITY__ (\
+	( (double) ( __OBDS_SQRT_OF_THREE_HALVES__ ) ) *\
+	( (double) ( __OBDS_SQRT_TIME_STEP__ ) )\
+)
+
+/* ``effective'' translational mobility of a hydrodynamically isotropic particle under the
+ * action of deterministic (or conservative) forces */
+#define __OBDS_ISOTROPIC_LINEAR_MOBILITY__  ( (double) ( __OBDS_TIME_STEP__ ) )
+
+#endif
+
+/*
+
+OpenBDS							September 05, 2023
+
+source: particle/params.h
+author: @misael-diaz
+
+Synopsis:
+Defines particle parameters.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util/particle.h
+++ b/inc/util/particle.h
@@ -3,7 +3,15 @@
 
 #include "bds/types.h"
 
-void util_particle_translate(particle_t*);
+#define util_particle_translate(particles, ...)\
+	util_particle_translate_varg(particles, (struct mobility) { __VA_ARGS__ })
+
+struct mobility
+{
+  void (*callback) (particle_t*);
+};
+
+void util_particle_translate_varg(particle_t*, struct mobility);
 void util_particle_pbcs(particle_t*);
 void util_particle_brute_force(particle_t* particles,
 			       void (*callback)(particle_t* particles,
@@ -33,5 +41,6 @@ References:
 [0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
 [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
 [2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+[3] https://stackoverflow.com/questions/1472138/c-default-arguments/2926165#2926165
 
 */


### PR DESCRIPTION
COMMENTS:
adds a variadic method for translating particles

the last argument of this method is optional, it is a callback that implements the computation of the ``effective mobility'' of the particle

for spheres, it is optional to pass this argument, for the default callback assumes that the particles are spheres

code has been added to test the code when the user opts to pass a callback

this shall be useful to handle anisotropic particles in a more general sense

initial code to handle anisotropic particle has also been added; however, it is not yet meant to be used and so a safe-guard has been added as well