### PR TITLE
refactors stochastic force comptation [clang]

### DIFF
--- a/inc/util/particle.h
+++ b/inc/util/particle.h
@@ -2,6 +2,7 @@
 #define GUARD_OPENBDS_UTIL_PARTICLE_H
 
 #include "bds/types.h"
+#include "util/random/type.h"
 
 #define util_particle_translate(particles, ...)\
 	util_particle_translate_varg(particles, (struct mobility) { __VA_ARGS__ })
@@ -13,6 +14,8 @@ struct mobility
 
 void util_particle_translate_varg(particle_t*, struct mobility);
 void util_particle_pbcs(particle_t*);
+int util_particle_stochastic_forces(random_t* random, particle_t* particles);
+int util_particle_stochastic_torques(random_t* random, particle_t* particles);
 void util_particle_brute_force(particle_t* particles,
 			       void (*callback)(particle_t* particles,
 						size_t const id,

--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -410,13 +410,17 @@ static void callback (particle_t* particles,
 static void sphere_mobility_callback (particle_t* particles)
 {
 #define LINEAR_DETERMINISTIC_MOBILITY ( (double) ( __OBDS_TIME_STEP__ ) )
+#define ANGULAR_DETERMINISTIC_MOBILITY ( 0.75 * ( (double) ( __OBDS_TIME_STEP__ ) ) )
 #if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
   constexpr double linear_mobility = LINEAR_DETERMINISTIC_MOBILITY;
+  constexpr double angular_mobility = ANGULAR_DETERMINISTIC_MOBILITY;
 #else
   double const linear_mobility = LINEAR_DETERMINISTIC_MOBILITY;
+  double const angular_mobility = ANGULAR_DETERMINISTIC_MOBILITY;
 #endif
   double* mobilities = &(particles -> bitmask -> data);
   mobilities[0] = linear_mobility;
+  mobilities[1] = angular_mobility;
 }
 #endif
 

--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -487,76 +487,6 @@ static void clamps (prop_t* __restrict__ f_x,
   clamp(f_z, tmp, temp, bitmask);
 }
 
-/*
-static int status (double const status)
-{
-  prop_t const error = { .data = status };
-  uint64_t const err = error.bin;
-  if (err == OBDS_ERR_PRNG)
-  {
-    return FAILURE;
-  }
-
-  return SUCCESS;
-}
-*/
-
-
-/*
-static int stochastic_force (random_t* random, prop_t* p_F_x)
-{
-  double* F_x = &p_F_x[0].data;
-  for (size_t i = 0; i != NUMEL; ++i)
-  {
-    double const rand = random -> fetch(random);
-    if (status(rand) == FAILURE)
-    {
-      return FAILURE;
-    }
-    F_x[i] = rand;
-  }
-
-  return SUCCESS;
-}
-*/
-
-/*
-static int stochastic_forces (random_t* random, prop_t* f_x, prop_t* f_y, prop_t* f_z)
-{
-  if (stochastic_force(random, f_x) == FAILURE)
-  {
-    return FAILURE;
-  }
-
-  if (stochastic_force(random, f_y) == FAILURE)
-  {
-    return FAILURE;
-  }
-
-  if (stochastic_force(random, f_z) == FAILURE)
-  {
-    return FAILURE;
-  }
-
-  return SUCCESS;
-}
-*/
-
-
-// shifts the particles along the x, y, or z axis due to deterministic force effects
-/*
-static void shift (prop_t* __restrict__ prop_x, const prop_t* __restrict__ prop_F_x)
-{
-  double const dt = TSTEP;
-  double* x = &prop_x[0].data;
-  const double* F_x = &prop_F_x[0].data;
-  for (size_t i = 0; i != NUMEL; ++i)
-  {
-    x[i] += (dt * F_x[i]);
-  }
-}
-*/
-
 
 static void stochastic_shift (prop_t* __restrict__ prop_x,
 			      const prop_t* __restrict__ prop_F_x)
@@ -583,22 +513,6 @@ static void stochastic_rotation (prop_t* __restrict__ prop_x,
     x[i] = (angular_stochastic_mobility * T_x[i]);
   }
 }
-
-
-// shifts the particles along the axes owing to the net deterministic forces
-/*
-static void shifts (prop_t* __restrict__ x,
-		    prop_t* __restrict__ y,
-		    prop_t* __restrict__ z,
-		    const prop_t* __restrict__ f_x,
-		    const prop_t* __restrict__ f_y,
-		    const prop_t* __restrict__ f_z)
-{
-  shift(x, f_x);
-  shift(y, f_y);
-  shift(z, f_z);
-}
-*/
 
 
 static void stochastic_shifts (prop_t* __restrict__ x,
@@ -872,10 +786,6 @@ static int updater (sphere_t* spheres)
   particle_t* particles = spheres -> props;
   util_particle_brute_force(particles, cb);
   clamps(f_x, f_y, f_z, tmp, temp, bitmask);
-  /*
-  shifts(r_x, r_y, r_z, f_x, f_y, f_z);
-  shifts(x, y, z, f_x, f_y, f_z);
-  */
 #if (SUPPLY_MOBILITY_CALLBACK == 1)
   util_particle_translate(particles, sphere_mobility_callback);
 #else
@@ -883,13 +793,6 @@ static int updater (sphere_t* spheres)
 #endif
   // we want to store the deterministic forces temporarily for logging purposes
   memcpy(list, f_x, 3LU * NUMEL * sizeof(prop_t));
-
-  /*
-  if (stochastic_forces(random, f_x, f_y, f_z) == FAILURE)
-  {
-    return FAILURE;
-  }
-  */
 
   if (util_particle_stochastic_forces(random, particles) == FAILURE)
   {
@@ -899,13 +802,6 @@ static int updater (sphere_t* spheres)
   stochastic_shifts(r_x, r_y, r_z, f_x, f_y, f_z);
   stochastic_shifts(x, y, z, f_x, f_y, f_z);
   vsum(f_x, list);
-
-  /*
-  if (stochastic_forces(random, t_x, t_y, t_z) == FAILURE)
-  {
-    return FAILURE;
-  }
-  */
 
   if (util_particle_stochastic_torques(random, particles) == FAILURE)
   {

--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -487,7 +487,7 @@ static void clamps (prop_t* __restrict__ f_x,
   clamp(f_z, tmp, temp, bitmask);
 }
 
-
+/*
 static int status (double const status)
 {
   prop_t const error = { .data = status };
@@ -499,8 +499,10 @@ static int status (double const status)
 
   return SUCCESS;
 }
+*/
 
 
+/*
 static int stochastic_force (random_t* random, prop_t* p_F_x)
 {
   double* F_x = &p_F_x[0].data;
@@ -516,8 +518,9 @@ static int stochastic_force (random_t* random, prop_t* p_F_x)
 
   return SUCCESS;
 }
+*/
 
-
+/*
 static int stochastic_forces (random_t* random, prop_t* f_x, prop_t* f_y, prop_t* f_z)
 {
   if (stochastic_force(random, f_x) == FAILURE)
@@ -537,6 +540,7 @@ static int stochastic_forces (random_t* random, prop_t* f_x, prop_t* f_y, prop_t
 
   return SUCCESS;
 }
+*/
 
 
 // shifts the particles along the x, y, or z axis due to deterministic force effects
@@ -879,15 +883,31 @@ static int updater (sphere_t* spheres)
 #endif
   // we want to store the deterministic forces temporarily for logging purposes
   memcpy(list, f_x, 3LU * NUMEL * sizeof(prop_t));
+
+  /*
   if (stochastic_forces(random, f_x, f_y, f_z) == FAILURE)
   {
     return FAILURE;
   }
+  */
+
+  if (util_particle_stochastic_forces(random, particles) == FAILURE)
+  {
+    return FAILURE;
+  }
+
   stochastic_shifts(r_x, r_y, r_z, f_x, f_y, f_z);
   stochastic_shifts(x, y, z, f_x, f_y, f_z);
   vsum(f_x, list);
 
+  /*
   if (stochastic_forces(random, t_x, t_y, t_z) == FAILURE)
+  {
+    return FAILURE;
+  }
+  */
+
+  if (util_particle_stochastic_torques(random, particles) == FAILURE)
   {
     return FAILURE;
   }

--- a/src/util/particle/make-inc
+++ b/src/util/particle/make-inc
@@ -21,6 +21,7 @@ FCONFG_H = ../../../inc/fconfig.h
 CONFIG_H = ../../../inc/config.h
 
 BDS_TYPES_H = ../../../inc/bds/types.h
+BDS_PARAMS_H = ../../../inc/bds/params.h
 
 SYSBOX_PARAMS_H = ../../../inc/system/box/params.h
 SYSBOX_UTILS_H = ../../../inc/system/box/utils.h
@@ -29,10 +30,13 @@ SYSBOX_H = ../../../inc/system/box.h
 SYSTEM_PARAMS_H = ../../../inc/system/params.h
 SYSTEM_H = ../../../inc/system.h
 
+UTIL_RANDOM_TYPE_H = ../../../inc/util/random/type.h
+UTIL_RANDOM_ERR_H = ../../../inc/util/random/err.h
 UTIL_PARTICLE_H = ../../../inc/util/particle.h
 
-HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(SYSBOX_PARAMS_H) $(SYSBOX_UTILS_H)\
-	  $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H) $(UTIL_PARTICLE_H)
+HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_PARAMS) $(BDS_TYPES_H) $(SYSBOX_PARAMS_H)\
+	  $(SYSBOX_UTILS_H) $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H)\
+	  $(UTIL_RANDOM_ERR_H) $(UTIL_RANDOM_TYPE_H) $(UTIL_PARTICLE_H)
 
 # sources
 PARTICLE_C = particle.c

--- a/src/util/particle/particle.c
+++ b/src/util/particle/particle.c
@@ -15,14 +15,17 @@
 static void default_particle_mobility_callback (particle_t* particles)
 {
 #define LINEAR_DETERMINISTIC_MOBILITY ( (double) ( __OBDS_TIME_STEP__ ) )
+#define ANGULAR_DETERMINISTIC_MOBILITY ( 0.75 * ( (double) ( __OBDS_TIME_STEP__ ) ) )
 #if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
   constexpr double linear_mobility = LINEAR_DETERMINISTIC_MOBILITY;
+  constexpr double angular_mobility = ANGULAR_DETERMINISTIC_MOBILITY;
 #else
   double const linear_mobility = LINEAR_DETERMINISTIC_MOBILITY;
+  double const angular_mobility = ANGULAR_DETERMINISTIC_MOBILITY;
 #endif
   double* mobilities = &(particles -> bitmask -> data);
   mobilities[0] = linear_mobility;
-  mobilities[1] = linear_mobility;
+  mobilities[1] = angular_mobility;
 }
 
 #if (ISOTROPIC_RESISTANCE == 0x00000001)

--- a/src/util/particle/particle.c
+++ b/src/util/particle/particle.c
@@ -1,9 +1,13 @@
+#include "util/random/err.h"
 #include "system/box/params.h"
 #include "system/box/utils.h"
 #include "system/params.h"
 #include "util/particle.h"
+#include "bds/params.h"
 
 #define STDC17 201710L
+#define SUCCESS ( (int) ( __OBDS_SUCCESS__ ) )
+#define FAILURE ( (int) ( __OBDS_FAILURE__ ) )
 #define TSTEP ( (double) ( __OBDS_TIME_STEP__ ) )
 #define NUMEL ( (size_t) ( __OBDS_NUM_PARTICLES__ ) )
 #define LENGTH ( (double) ( __OBDS_LENGTH__ ) )
@@ -145,6 +149,100 @@ void util_particle_translate_varg (particle_t* particles, struct mobility mobili
 }
 
 #endif
+
+
+// checks the underlying status code in the binary pattern of the floating-point number
+// `status' to determine if an error related to the generation of pseudo-random numbers
+// has occurred
+static int status (double const status)
+{
+  prop_t const error = { .data = status };
+  uint64_t const err = error.bin;
+  if (err == OBDS_ERR_PRNG)
+  {
+    return FAILURE;
+  }
+
+  return SUCCESS;
+}
+
+
+// computes the `x' component of the stochastic (or random) force vector
+static int stochastic_force (random_t* random, double* f_x)
+{
+  for (size_t i = 0; i != NUMEL; ++i)
+  {
+    double const rand = random -> fetch(random);
+    if (status(rand) == FAILURE)
+    {
+      return FAILURE;
+    }
+    f_x[i] = rand;
+  }
+
+  return SUCCESS;
+}
+
+
+// computes the `x' component of the stochastic (or random) torque vector
+static int stochastic_torque (random_t* random, double* t_x)
+{
+  // we can afford to use the same function because both the stochastic forces and torques
+  // are non-dimensional but share the same statistical properties of zero mean and unit
+  // variance
+  return stochastic_force(random, t_x);
+}
+
+
+// updates the components of the stochastic force vector
+int util_particle_stochastic_forces (random_t* random, particle_t* particles)
+{
+  double* f_x = &(particles -> f_x -> data);
+  double* f_y = &(particles -> f_y -> data);
+  double* f_z = &(particles -> f_z -> data);
+  if (stochastic_force(random, f_x) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  if (stochastic_force(random, f_y) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  if (stochastic_force(random, f_z) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  return SUCCESS;
+}
+
+
+// updates the components of the stochastic torque vector
+int util_particle_stochastic_torques (random_t* random, particle_t* particles)
+{
+  double* t_x = &(particles -> t_x -> data);
+  double* t_y = &(particles -> t_y -> data);
+  double* t_z = &(particles -> t_z -> data);
+  if (stochastic_torque(random, t_x) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  if (stochastic_torque(random, t_y) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  if (stochastic_torque(random, t_z) == FAILURE)
+  {
+    return FAILURE;
+  }
+
+  return SUCCESS;
+}
+
 
 // void util_particle_bruteforce(particles, callback)
 //


### PR DESCRIPTION
refactors the computation of stochastic forces done in src/particle/sphere.c to src/util/particle/particle.c so that later on we can reuse these functions for other particle types

defines the "effective" angular mobility for completeness even if it is not going to be used anytime soon, for there are no conservative torques acting on the spheres 