### PR TITLE
forward declares `struct random' [clang]

### DIFF
--- a/inc/particle/sphere/type.h
+++ b/inc/particle/sphere/type.h
@@ -2,7 +2,6 @@
 #define GUARD_OPENBDS_PARTICLE_SPHERE_TYPE_H
 
 #include "bds/types.h"
-#include "util/random/type.h"
 
 // defines enum for selecting the logging level
 enum SPHLOG
@@ -16,10 +15,13 @@ typedef enum SPHLOG SPHLOG;
 typedef struct __OBDS_PARTICLE_TYPE__ __OBDS_SPHERE_TYPE__ ;
 typedef __OBDS_SPHERE_TYPE__ OBDS_Sphere_t;
 
+// forward declares the underlying type of the Pseudo Random Number Generator `random_t'
+struct random;
+
 struct sphere
 {
   OBDS_Sphere_t* props;			// properties
-  random_t* prng;			// Pseudo Random Number Generator PRNG
+  struct random* prng;			// Pseudo Random Number Generator PRNG
   int (*update) (struct sphere*);	// updates the particles position and orientation
   int (*log) (const struct sphere* spheres, size_t const step);	// logs the positions
 };

--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -11,6 +11,7 @@
 #include "system/box.h"
 #include "particle/sphere/params.h"
 #include "particle/sphere/type.h"
+#include "util/random/type.h"
 #include "util/particle.h"
 #include "util/arrays.h"
 #include "util/type.h"

--- a/src/test/particle-sphere/test.c
+++ b/src/test/particle-sphere/test.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include "system/box/params.h"
+#include "util/random/type.h"
 #include "particle/sphere/params.h"
 #include "particle/sphere/utils.h"
 


### PR DESCRIPTION
COMMENTS:
it is really not necessary to include `util/random/type.h` in the header `particle/sphere/type.h` which defines the `sphere_t` since we only need a pointer to the Pseudo Random Number Generator PRNG

it is better to include PRNG headers in the implementation file `particle/sphere/sphere.c`, for we need to know its details in order to setup the OBDS `workspace`