### PR TITLE
adds __OBDS_ERR_PRNG__ MACRO [clang]

### DIFF
--- a/inc/bds/params.h
+++ b/inc/bds/params.h
@@ -3,6 +3,7 @@
 
 #define __OBDS_SUCCESS__ ( (int) 0x00000000 )
 #define __OBDS_FAILURE__ ( (int) 0xffffffff )
+#define __OBDS_ERR_PRNG__ ( (uint64_t) 0xfff0000000000000 )
 
 #endif
 

--- a/inc/util/random/err.h
+++ b/inc/util/random/err.h
@@ -1,7 +1,9 @@
 #ifndef GUARD_OPENBDS_UTIL_RANDOM_ERR_H
 #define GUARD_OPENBDS_UTIL_RANDOM_ERR_H
 
-#define OBDS_ERR_PRNG ( (uint64_t) 0xfff0000000000000 )
+#include "bds/params.h"
+
+#define OBDS_ERR_PRNG __OBDS_ERR_PRNG__
 
 #endif
 


### PR DESCRIPTION
COMMENTS:
adds __OBDS_ERR_PRNG__ MACRO to `bds/params.h` as it should be