### PR TITLE
includes PRNG type in the Particle's implementation file [clang]

### DIFF
--- a/inc/util/particle.h
+++ b/inc/util/particle.h
@@ -2,7 +2,6 @@
 #define GUARD_OPENBDS_UTIL_PARTICLE_H
 
 #include "bds/types.h"
-#include "util/random/type.h"
 
 // translates particles by the conservative forces acting on them, variadic, optional
 // callback for spheres (all the other particle types must supply it)
@@ -20,9 +19,9 @@ void util_particle_translate_varg(particle_t*, struct mobility);
 // applies periodic boundary conditions on the position vectors of the particles
 void util_particle_pbcs(particle_t*);
 // samples the stochastic forces from the Gausian PRNG
-int util_particle_stochastic_forces(random_t* random, particle_t* particles);
+int util_particle_stochastic_forces(struct random* random, particle_t* particles);
 // samples the stochastic torques from the Gausian PRNG
-int util_particle_stochastic_torques(random_t* random, particle_t* particles);
+int util_particle_stochastic_torques(struct random* random, particle_t* particles);
 // uses brute-force to obtain the resultant determintic force acting on the particles,
 // the callback implements interaction between pairs of virtual particles; the `offsets'
 // are used to consider interactions with the virtual particles (when the `offsets' are

--- a/src/util/particle/particle.c
+++ b/src/util/particle/particle.c
@@ -1,4 +1,5 @@
 #include "util/random/err.h"
+#include "util/random/type.h"
 #include "system/box/params.h"
 #include "system/box/utils.h"
 #include "system/params.h"


### PR DESCRIPTION
COMMENTS:
it is not necessary to include `util/random/type.h` in the header `util/particle.h`, since the PRNG is part of the implementation of the methods that operate on the particles; this is why it is now included in the implementation file `util/particle.c`