### PR TITLE
adds util/random/initializer.h [clang]

### DIFF
--- a/inc/util/random.h
+++ b/inc/util/random.h
@@ -2,6 +2,7 @@
 #define GUARD_OPENBDS_UTIL_RANDOM_H
 
 #include "util/random/err.h"
+#include "util/random/initializer.h"
 #include "util/random/type.h"
 
 #endif

--- a/inc/util/random/initializer.h
+++ b/inc/util/random/initializer.h
@@ -1,0 +1,35 @@
+#ifndef GUARD_OPENBDS_UTIL_RANDOM_INITIALIZER_H
+#define GUARD_OPENBDS_UTIL_RANDOM_INITIALIZER_H
+
+// forward declarations:
+
+enum PRNG;
+struct random;
+
+// utils:
+
+int util_random_initializer(struct random*, enum PRNG);
+
+#endif
+
+/*
+
+OpenBDS							October 04, 2023
+
+source: util/random/initializer.h
+author: @misael-diaz
+
+Synopsis:
+Provides prototype for the Pseudo Random Number Generator PRNG initializer.
+
+Copyright (c) 2023 Misael Diaz-Maldonado
+This file is released under the GNU General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+References:
+[0] A Koenig and B Moo, Accelerated C++ Practical Programming by Example.
+[1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+[2] S Kim and S Karrila, Microhydrodynamics: Principles and Selected Applications.
+
+*/

--- a/inc/util/random/type.h
+++ b/inc/util/random/type.h
@@ -25,8 +25,6 @@ struct random
 
 typedef struct random random_t;
 
-int util_random_initializer(random_t*, enum PRNG);
-
 #endif
 
 /*

--- a/src/particle/sphere/make-inc
+++ b/src/particle/sphere/make-inc
@@ -35,6 +35,7 @@ UPRTCL_H = ../../../inc/util/particle.h
 
 RNDERR_H = ../../../inc/util/random/err.h
 RANDTP_H = ../../../inc/util/random/type.h
+RANDIN_H = ../../../inc/util/random/initializer.h
 RANDOM_H = ../../../inc/util/random.h
 
 SPHERE_TYPE_H = ../../../inc/particle/sphere/type.h
@@ -44,7 +45,7 @@ SPHERE_H = ../../../inc/particle/sphere.h
 
 HEADERS = $(FCONFG_H) $(CONFIG_H) $(BDS_TYPES_H) $(BDS_PARAMS_H) $(SYSBOX_PARAMS_H)\
 	  $(SYSBOX_UTILS_H) $(SYSBOX_H) $(SYSTEM_PARAMS_H) $(SYSTEM_H) $(ARRAYS_H)\
-	  $(RNDERR_H) $(RANDTP_H) $(RANDOM_H) $(SPHERE_TYPE_H) $(UPRTCL_H)\
+	  $(RNDERR_H) $(RANDTP_H) $(RANDIN_H) $(RANDOM_H) $(SPHERE_TYPE_H) $(UPRTCL_H)\
 	  $(SPHERE_PARAMS_H) $(SPHERE_UTILS_H) $(SPHERE_H)
 
 # sources

--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -11,6 +11,7 @@
 #include "system/box.h"
 #include "particle/sphere/params.h"
 #include "particle/sphere/type.h"
+#include "util/random/initializer.h"
 #include "util/random/type.h"
 #include "util/particle.h"
 #include "util/array.h"

--- a/src/test/random/test.c
+++ b/src/test/random/test.c
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "util/random.h"
+#include "util/random/initializer.h"
 
 #define STDC17 201710L
 #define ABS(x) ( (x < 0)? -x : x )

--- a/src/test/random/test.c
+++ b/src/test/random/test.c
@@ -7,7 +7,6 @@
 #include <math.h>
 
 #include "util/random.h"
-#include "util/random/initializer.h"
 
 #define STDC17 201710L
 #define ABS(x) ( (x < 0)? -x : x )

--- a/src/util/random/make-inc
+++ b/src/util/random/make-inc
@@ -19,10 +19,11 @@ INC = -I../../../inc
 # headers
 BDSPRM_H = ../../../inc/bds/params.h
 RNDERR_H = ../../../inc/util/random/err.h
+RANDIN_H = ../../../inc/util/random/initializer.h
 RANDTP_H = ../../../inc/util/random/type.h
 RANDOM_H = ../../../inc/util/random.h
 
-HEADERS = $(BDSPRM_H) $(RNDERR_H) $(RANDTP_H) $(RANDOM_H)
+HEADERS = $(BDSPRM_H) $(RNDERR_H) $(RANDTP_H) $(RANDIN_H) $(RANDOM_H)
 
 # sources
 RANDOM_C = random.c

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -13,8 +13,9 @@
 #include <math.h>	// for generating normally distributed pseudo-random numbers
 
 #include "bds/params.h"
+#include "util/random/err.h"
 #include "util/random/initializer.h"
-#include "util/random.h"
+#include "util/random/type.h"
 
 #define STDC17 201710L
 #define FAILURE ( (int) ( __OBDS_FAILURE__ ) )

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -20,9 +20,7 @@
 #define STDC17 201710L
 #define FAILURE ( (int) ( __OBDS_FAILURE__ ) )
 #define SUCCESS ( (int) ( __OBDS_SUCCESS__ ) )
-#define MSBMASK ( (int64_t) 0x8000000000000000 )
 #define PERIOD ( (uint64_t) 0xffffffffffffffff )
-#define SCALING ( 1.0 / ( (double) MSBMASK ) )
 // 64-bit binary floatint-poing representation of 2^N
 #define BIAS ( (uint64_t) 1023 )
 #define EXP(N) ( (N + BIAS) << 52 )
@@ -127,38 +125,18 @@ static int seeder (generator_t* generator)
 }
 
 
-// double sxorshift64(int64_t* state)
+// double xorshift64(generator)
 //
 // Synopsis:
 // Implements Marsaglia's 64-bit xorshift Pseudo Random Number Generator PRNG.
 // Yields uniformly distributed pseudo-random numbers in [0, 1).
-// This implementation uses signed 64-bit integer for interoperability with FORTRAN.
 //
-// Input:
-// state	initial state of the pseudo-random number generator
+// Parameters:
+// generator	(intent inout) the pseudo-random number generator PRNG
 //
-// Output:
-// state	updated state
-//
-// Return:
+// Returns:
 // prn		uniformly distributed pseudo-random number in [0, 1)
 
-
-double sxorshift64 (int64_t* state)
-{
-  int64_t x = *state;
-  x ^= (x << 13);
-  x ^= (x >> 7);
-  x ^= (x << 17);
-  *state = x;
-
-  double const c = SCALING;
-  double const r = c * x;
-  return ( 0.5 * (r + 1.0) );
-}
-
-
-// as sxorshift64() but uses unsigned 64-bit integers to update the PRNG state
 static double xorshift64 (generator_t* generator)
 {
   uint64_t x = *(generator -> state);

--- a/src/util/random/random.c
+++ b/src/util/random/random.c
@@ -13,6 +13,7 @@
 #include <math.h>	// for generating normally distributed pseudo-random numbers
 
 #include "bds/params.h"
+#include "util/random/initializer.h"
 #include "util/random.h"
 
 #define STDC17 201710L


### PR DESCRIPTION
- places the PRNG initializer in its own header
- fixes unsigned integer initialization in `xorshift64()`

other things that might be worth mentioning

it is interesting that neither GCC nor LLVM warned about this until `constexpr` was used

had to define a local `union alias` to be able to use `constexpr`