### PR TITLE
deletes local vector utils in particle/sphere [clang]

### DIFF
--- a/src/particle/sphere/sphere.c
+++ b/src/particle/sphere/sphere.c
@@ -122,16 +122,6 @@ static void inrange (const prop_t* __restrict__ dist, prop_t* __restrict__ bitma
 
 
 // zeroes the x, y, and z components of the force
-/*
-static void zeroes (prop_t* __restrict__ f_x,
-		    prop_t* __restrict__ f_y,
-		    prop_t* __restrict__ f_z)
-{
-  zeros(f_x);
-  zeros(f_y);
-  zeros(f_z);
-}
-*/
 
 
 // static double max (vectors)
@@ -148,41 +138,6 @@ static void zeroes (prop_t* __restrict__ f_x,
 // pass a pointer to the `x' component array and traverse the other two arrays in one
 // sweep since we know their sizes at compile-time.
 
-/*
-static double max (const prop_t* vectors)
-{
-  double max = 0;
-  for (size_t i = 0; i != (3 * NUMEL); ++i)
-  {
-    uint64_t const bin = vectors[i].bin;
-    prop_t const p = { .bin = ( bin & (~MSB) ) };
-    double const data = p.data;
-    if (data > max)
-    {
-      max = data;
-    }
-  }
-  return max;
-}
-
-
-// as max(), yields the absolute minimum component of the OBDS property `vector'
-static double min (const prop_t* vectors)
-{
-  double min = DBL_MAX;
-  for (size_t i = 0; i != (3 * NUMEL); ++i)
-  {
-    uint64_t const bin = vectors[i].bin;
-    prop_t const p = { .bin = ( bin & (~MSB) ) };
-    double const data = p.data;
-    if (data < min)
-    {
-      min = data;
-    }
-  }
-  return min;
-}
-*/
 
 
 // void SLJ (dist, force, bitmask)
@@ -746,17 +701,6 @@ static void grid (prop_t* __restrict__ xprop,
 
 
 // sums `src' and `dst' vectors (elementwise), stores the result in `dst'
-/*
-static void vsum (prop_t* __restrict__ dest, const prop_t* __restrict__ source)
-{
-  double* dst = &(dest[0].data);
-  const double* src = &(source[0].data);
-  for (size_t i = 0; i != (3 * NUMEL); ++i)
-  {
-    dst[i] += src[i];
-  }
-}
-*/
 
 
 // updates the positions of the particles due to the forces acting on them
@@ -786,9 +730,6 @@ static int updater (sphere_t* spheres)
   prop_t* bitmask = spheres -> props -> bitmask;
   prop_t* list = spheres -> props -> list;
   random_t* random = spheres -> prng;
-  /*
-  zeroes(f_x, f_y, f_z);
-  */
   util_vector_zeros(f_x);
   void (*cb) (particle_t* particles,
 	      size_t const i,
@@ -813,9 +754,6 @@ static int updater (sphere_t* spheres)
 
   stochastic_shifts(r_x, r_y, r_z, f_x, f_y, f_z);
   stochastic_shifts(x, y, z, f_x, f_y, f_z);
-  /*
-  vsum(f_x, list);
-  */
   util_vector_sum(f_x, list);
 
   if (util_particle_BrownianTorques(random, particles) == FAILURE)
@@ -900,11 +838,6 @@ static int logger_verbose (const sphere_t* spheres, size_t const step)
     return FAILURE;
   }
 
-  /*
-  const prop_t* force = spheres -> props -> f_x;
-  double const f_min = min(force);
-  double const f_max = max(force);
-  */
   const vector_t* force = spheres -> props -> f_x;
   double const f_min = util_vector_min(force);
   double const f_max = util_vector_max(force);


### PR DESCRIPTION
COMMENTS:
deletes local vector utils present in particle/sphere, for these have been already refactored into their own module util/vector