### PR TITLE
adds initial OBDS-API [FORTRAN]

### DIFF
--- a/api/fortran/Makefile
+++ b/api/fortran/Makefile
@@ -2,7 +2,7 @@
 #
 # OpenBDS						July 19, 2023
 #
-# source: api/Makefile
+# source: api/fortran/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,14 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+all: modules tests
 
-api-clang:
-	@$(MAKE) -C clang
+modules:
+	@$(MAKE) -C module
 
-api-fortran:
-	@$(MAKE) -C fortran
+tests: modules
+	@$(MAKE) -C test
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	@$(MAKE) -C module clean
+	@$(MAKE) -C test clean

--- a/api/fortran/module/Makefile
+++ b/api/fortran/module/Makefile
@@ -2,7 +2,7 @@
 #
 # OpenBDS						July 19, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,18 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+all: OBDS-constants particles spheres
 
-api-clang:
-	@$(MAKE) -C clang
+OBDS-constants:
+	@$(MAKE) -C constants
 
-api-fortran:
-	@$(MAKE) -C fortran
+particles: OBDS-constants
+	@$(MAKE) -C particle
+
+spheres: particles
+	@$(MAKE) -C sphere
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	@$(MAKE) -C constants clean
+	@$(MAKE) -C particle clean
+	@$(MAKE) -C sphere clean

--- a/api/fortran/module/constants/Makefile
+++ b/api/fortran/module/constants/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/constants/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,12 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+include make-inc
 
-api-clang:
-	@$(MAKE) -C clang
+all: $(CONSTANTS_O)
 
-api-fortran:
-	@$(MAKE) -C fortran
+$(CONSTANTS_O): $(CONSTANTS_F)
+	$(FC) $(FCOPT) -ffixed-form -c $(CONSTANTS_F) -o $(CONSTANTS_O) -J $(MODS)
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	/bin/rm -f *.o

--- a/api/fortran/module/constants/constants.f
+++ b/api/fortran/module/constants/constants.f
@@ -1,0 +1,39 @@
+      module constants
+        use, intrinsic :: iso_fortran_env, only: int64
+c       use, intrinsic :: iso_fortran_env, only: real64
+        implicit none
+        private
+        save
+        public :: NUM_PARTICLES
+
+        integer(kind = int64), parameter :: NUM_PARTICLES = 256_int64
+
+      end module constants
+
+*   OpenBDS                                             October 21, 2023
+*
+*   source: api/fortran/module/constants/constants.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Defines OBDS Constants.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.

--- a/api/fortran/module/constants/make-inc
+++ b/api/fortran/module/constants/make-inc
@@ -1,8 +1,7 @@
-#!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/constants/make-inc
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +13,11 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+# sources
+CONSTANTS_F = constants.f
 
-api-clang:
-	@$(MAKE) -C clang
+# objects
+CONSTANTS_O = constants.o
 
-api-fortran:
-	@$(MAKE) -C fortran
-
-clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+# output directory the FORTRAN module files *.mod
+MODS = ../mods

--- a/api/fortran/module/particle/Makefile
+++ b/api/fortran/module/particle/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/particle/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,12 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+include make-inc
 
-api-clang:
-	@$(MAKE) -C clang
+all: $(PARTICLE_O)
 
-api-fortran:
-	@$(MAKE) -C fortran
+$(PARTICLE_O): $(MODULES) $(PARTICLE_F)
+	$(FC) $(FCOPT) -ffixed-form -c $(PARTICLE_F) -o $(PARTICLE_O) -J $(MODS)
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	/bin/rm -f *.o

--- a/api/fortran/module/particle/make-inc
+++ b/api/fortran/module/particle/make-inc
@@ -1,8 +1,7 @@
-#!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/particle/make-inc
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +13,15 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+# modules
+CONSTANTS_MOD = ../mods/constants.mod
+MODULES = $(CONSTANTS_MOD)
 
-api-clang:
-	@$(MAKE) -C clang
+# sources
+PARTICLE_F = particle.f
 
-api-fortran:
-	@$(MAKE) -C fortran
+# objects
+PARTICLE_O = particle.o
 
-clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+# output directory the FORTRAN module files *.mod
+MODS = ../mods

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -1,0 +1,291 @@
+      module particle
+        use, intrinsic :: iso_fortran_env, only: int64
+        use, intrinsic :: iso_fortran_env, only: real64
+        use :: constants, only: NUM_PARTICLES
+        implicit none
+        private
+
+        type, abstract, public :: particle_t
+c         position vector components (subjected to periodic conditions)
+          real(kind = real64), pointer, contiguous :: x(:) => null()
+          real(kind = real64), pointer, contiguous :: y(:) => null()
+          real(kind = real64), pointer, contiguous :: z(:) => null()
+c         Verlet displacement vector components
+          real(kind = real64), pointer, contiguous :: Vdx(:) => null()
+          real(kind = real64), pointer, contiguous :: Vdy(:) => null()
+          real(kind = real64), pointer, contiguous :: Vdz(:) => null()
+c         position vector components (periodic conditions independent)
+          real(kind = real64), pointer, contiguous :: r_x(:) => null()
+          real(kind = real64), pointer, contiguous :: r_y(:) => null()
+          real(kind = real64), pointer, contiguous :: r_z(:) => null()
+c         Euler angle vector components
+          real(kind = real64), pointer, contiguous :: Eax(:) => null()
+          real(kind = real64), pointer, contiguous :: Eay(:) => null()
+          real(kind = real64), pointer, contiguous :: Eaz(:) => null()
+c         orientation (or director) vector components
+          real(kind = real64), pointer, contiguous :: d_x(:) => null()
+          real(kind = real64), pointer, contiguous :: d_y(:) => null()
+          real(kind = real64), pointer, contiguous :: d_z(:) => null()
+c         force vector components
+          real(kind = real64), pointer, contiguous :: f_x(:) => null()
+          real(kind = real64), pointer, contiguous :: f_y(:) => null()
+          real(kind = real64), pointer, contiguous :: f_z(:) => null()
+c         torque vector components
+          real(kind = real64), pointer, contiguous :: t_x(:) => null()
+          real(kind = real64), pointer, contiguous :: t_y(:) => null()
+          real(kind = real64), pointer, contiguous :: t_z(:) => null()
+c         temporary placeholder
+          real(kind = real64), pointer, contiguous :: tmp(:) => null()
+c         Verlet neighbor-list
+          real(kind = real64), pointer, contiguous :: Vnl(:) => null()
+c         particle identifiers IDs
+          real(kind = real64), pointer, contiguous :: id(:) => null()
+c         data placeholder
+          real(kind = real64), pointer, contiguous :: data(:) => null()
+          contains
+            private
+            procedure :: initializer    ! memory allocations and initializations
+c           bindings:
+            procedure, public :: initialize => initializer
+c           updates the particle positions and orientations
+            procedure(updater), deferred, public :: update
+        end type particle_t
+
+        interface
+          subroutine updater(particles)
+            import particle_t
+            class(particle_t), intent(inout) :: particles
+          end subroutine
+        end interface
+
+        contains
+
+          subroutine iota (x)
+c           Synopsis:
+c           implements a std::iota C++ like method
+c           fills array `x' with values in symmetric range [1, numel]
+            integer(kind = int64), parameter :: numel = NUM_PARTICLES
+            real(kind = real64), intent(out) :: x(numel)
+            integer(kind = int64) :: i
+
+            do i = 1, numel
+              x(i) = real(i, kind = real64)
+            end do
+
+            return
+          end subroutine iota
+
+
+          subroutine initializer (particles)
+c           Synopsis:
+c           Particles Initializer.
+c           In the Object-Oriented Programming OOP sense this subroutine initializes the
+c           core of the particle objects (though bear in mind that we are handling them
+c           as a collection and not as individual objects so that we can ultimately write
+c           loops in a way that the compiler can optimize them via auto-vectorization).
+c           NOTES:
+c           The constructor of the extending classes must invoke this subroutine, as you
+c           would do in C++ or Java.
+            class(particle_t), intent(inout) :: particles
+            real(kind = real64), pointer, contiguous :: id(:) => null()
+            integer(kind = int64), parameter :: N = NUM_PARTICLES
+c           size position vector
+            integer(kind = int64), parameter :: size_x = N
+            integer(kind = int64), parameter :: size_y = N
+            integer(kind = int64), parameter :: size_z = N
+c           size Verlet displacement vector
+            integer(kind = int64), parameter :: size_Vdx = N
+            integer(kind = int64), parameter :: size_Vdy = N
+            integer(kind = int64), parameter :: size_Vdz = N
+c           size absolute position vector
+            integer(kind = int64), parameter :: size_r_x = N
+            integer(kind = int64), parameter :: size_r_y = N
+            integer(kind = int64), parameter :: size_r_z = N
+c           size Euler angle vector
+            integer(kind = int64), parameter :: size_Eax = N
+            integer(kind = int64), parameter :: size_Eay = N
+            integer(kind = int64), parameter :: size_Eaz = N
+c           size director (or orientation) vector
+            integer(kind = int64), parameter :: size_d_x = N
+            integer(kind = int64), parameter :: size_d_y = N
+            integer(kind = int64), parameter :: size_d_z = N
+c           size force vector
+            integer(kind = int64), parameter :: size_f_x = N
+            integer(kind = int64), parameter :: size_f_y = N
+            integer(kind = int64), parameter :: size_f_z = N
+c           size torque vector
+            integer(kind = int64), parameter :: size_t_x = N
+            integer(kind = int64), parameter :: size_t_y = N
+            integer(kind = int64), parameter :: size_t_z = N
+c           size temporary placeholder
+            integer(kind = int64), parameter :: size_tmp = N
+c           size Verlet neighbor-list (NOTE: we shall allocate more later)
+            integer(kind = int64), parameter :: size_Vnl = N
+c           size particle identifiers IDs
+            integer(kind = int64), parameter :: size_id = N
+c           sizes position vector
+            integer(kind = int64), parameter :: size_data = size_x +
+     +                                                      size_y +
+     +                                                      size_z +
+c           sizes Verlet displacement vector
+     +                                                      size_Vdx +
+     +                                                      size_Vdy +
+     +                                                      size_Vdz +
+c           sizes absolute position vector
+     +                                                      size_r_x +
+     +                                                      size_r_y +
+     +                                                      size_r_z +
+c           sizes Euler angle vector
+     +                                                      size_Eax +
+     +                                                      size_Eay +
+     +                                                      size_Eaz +
+c           sizes director (or orientation) vector
+     +                                                      size_d_x +
+     +                                                      size_d_y +
+     +                                                      size_d_z +
+c           sizes force vector
+     +                                                      size_f_x +
+     +                                                      size_f_y +
+     +                                                      size_f_z +
+c           sizes torque vector
+     +                                                      size_t_x +
+     +                                                      size_t_y +
+     +                                                      size_t_z +
+c           sizes temporary placeholder
+     +                                                      size_tmp +
+c           sizes Verlet neighbor-list
+     +                                                      size_Vnl +
+c           sizes particle identifiers IDs
+     +                                                      size_id
+c           memory allocation status
+            integer(kind = int64) :: mstat
+c           size
+            integer(kind = int64) :: sz
+
+c           allocates memory for the particle data
+            allocate(particles % data(size_data), stat = mstat)
+            if (mstat /= 0_int64) then
+              error stop "particle::initializer(): allocation error"
+            end if
+
+c           initializes the particle data with zeros
+            particles % data = 0.0_real64
+
+c           position vector binding
+            sz = 0_int64
+            particles % x => particles % data(sz + 1:sz + size_x)
+
+            sz = sz + size_x
+            particles % y => particles % data(sz + 1:sz + size_y)
+
+            sz = sz + size_y
+            particles % z => particles % data(sz + 1:sz + size_z)
+
+c           Verlet displacement vector binding
+            sz = sz + size_z
+            particles % Vdx => particles % data(sz + 1:sz + size_Vdx)
+
+            sz = sz + size_Vdx
+            particles % Vdy => particles % data(sz + 1:sz + size_Vdy)
+
+            sz = sz + size_Vdy
+            particles % Vdz => particles % data(sz + 1:sz + size_Vdz)
+
+c           absolute position vector binding
+            sz = sz + size_Vdz
+            particles % r_x => particles % data(sz + 1:sz + size_r_x)
+
+            sz = sz + size_r_x
+            particles % r_y => particles % data(sz + 1:sz + size_r_y)
+
+            sz = sz + size_r_y
+            particles % r_z => particles % data(sz + 1:sz + size_r_z)
+
+c           Euler angles vector binding
+            sz = sz + size_r_z
+            particles % Eax => particles % data(sz + 1:sz + size_Eax)
+
+            sz = sz + size_Eax
+            particles % Eay => particles % data(sz + 1:sz + size_Eay)
+
+            sz = sz + size_Eay
+            particles % Eaz => particles % data(sz + 1:sz + size_Eaz)
+
+c           director (or orientation) vector binding
+            sz = sz + size_Eaz
+            particles % d_x => particles % data(sz + 1:sz + size_d_x)
+
+            sz = sz + size_d_x
+            particles % d_y => particles % data(sz + 1:sz + size_d_y)
+
+            sz = sz + size_d_y
+            particles % d_z => particles % data(sz + 1:sz + size_d_z)
+
+c           force vector binding
+            sz = sz + size_d_z
+            particles % f_x => particles % data(sz + 1:sz + size_f_x)
+
+            sz = sz + size_f_x
+            particles % f_y => particles % data(sz + 1:sz + size_f_y)
+
+            sz = sz + size_f_z
+            particles % f_z => particles % data(sz + 1:sz + size_f_z)
+
+c           torque vector binding
+            sz = sz + size_f_z
+            particles % t_x => particles % data(sz + 1:sz + size_t_x)
+
+            sz = sz + size_t_x
+            particles % t_y => particles % data(sz + 1:sz + size_t_y)
+
+            sz = sz + size_t_y
+            particles % t_z => particles % data(sz + 1:sz + size_t_z)
+
+c           temporary placeholder binding
+            sz = sz + size_t_z
+            particles % tmp => particles % data(sz + 1:sz + size_tmp)
+
+c           Verlet neighbor-list binding
+            sz = sz + size_tmp
+            particles % Vnl => particles % data(sz + 1:sz + size_Vnl)
+
+c           particle identifier IDs binding
+            sz = sz + size_Vnl
+            particles % id => particles % data(sz + 1:sz + size_id)
+
+c           assigns unique IDs to the particles
+            id => particles % id
+            call iota(id)
+
+            return
+          end subroutine initializer
+
+      end module particle
+
+*   OpenBDS                                             October 21, 2023
+*
+*   source: api/fortran/module/particle/particle.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Defines the Core Particle Type.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.

--- a/api/fortran/module/sphere/Makefile
+++ b/api/fortran/module/sphere/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/sphere/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,12 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+include make-inc
 
-api-clang:
-	@$(MAKE) -C clang
+all: $(SPHERE_O)
 
-api-fortran:
-	@$(MAKE) -C fortran
+$(SPHERE_O): $(MODULES) $(SPHERE_F)
+	$(FC) $(FCOPT) -ffixed-form -c $(SPHERE_F) -o $(SPHERE_O) -J $(MODS)
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	/bin/rm -f *.o

--- a/api/fortran/module/sphere/make-inc
+++ b/api/fortran/module/sphere/make-inc
@@ -1,8 +1,7 @@
-#!/usr/bin/make
 #
-# OpenBDS						July 19, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/Makefile
+# source: api/fortran/module/sphere/make-inc
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +13,15 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+# modules
+CONSTANTS_MOD = ../mods/constants.mod
+MODULES = $(CONSTANTS_MOD)
 
-api-clang:
-	@$(MAKE) -C clang
+# sources
+SPHERE_F = sphere.f
 
-api-fortran:
-	@$(MAKE) -C fortran
+# objects
+SPHERE_O = sphere.o
 
-clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+# output directory the FORTRAN module files *.mod
+MODS = ../mods

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -1,0 +1,113 @@
+      module sphere
+        use, intrinsic :: iso_fortran_env, only: int64
+        use, intrinsic :: iso_fortran_env, only: real64
+        use :: constants, only: NUM_SPHERES => NUM_PARTICLES
+        use :: particle, only: particle_t
+        implicit none
+        private
+        save
+
+c       parameters:
+
+c       sphere radius, diameter, and contact-distance
+        real(kind = real64), parameter :: RADIUS = 1.0_real64
+        real(kind = real64), parameter :: DIAMETER = 2.0_real64 * RADIUS
+        real(kind = real64), parameter :: CONTACT = DIAMETER
+
+        type, extends(particle_t), public :: sphere_t
+          contains
+            private
+            procedure :: updater
+            procedure, public :: update => updater
+            final :: destructor
+        end type
+
+        interface sphere_t
+          module procedure constructor
+        end interface
+
+        contains
+
+          function constructor () result(spheres)
+c           Synopsis:
+c           Allocates resources and initializes the spheres.
+            type(sphere_t), pointer :: spheres
+            integer(kind = int64) :: mstat
+
+c           memory allocations:
+            spheres => null()
+            allocate(spheres, stat = mstat)
+            if (mstat /= 0_int64) then
+              error stop "sphere_t(): memory allocation error"
+            end if
+
+c           initializations:
+            call spheres % initialize()
+
+            return
+          end function constructor
+
+
+          subroutine updater (particles)
+c           Synopsis:
+c           Initial implementation so that the compiler won't complain.
+            class(sphere_t), intent(inout) :: particles
+
+            print *, 'sphere::update(): unimplemented'
+
+            return
+          end subroutine updater
+
+
+          subroutine destructor (spheres)
+c           Synopsis:
+c           Frees resources allocated for the spheres.
+            type(sphere_t), intent(inout) :: spheres
+            integer(kind = int64) :: mstat
+            character(*), parameter :: errmsg =
+     +      "sphere::destructor(): unexpected memory deallocation error"
+
+            if ( associated(spheres % data) ) then
+
+              deallocate(spheres % data, stat = mstat)
+
+              if (mstat /= 0_int64) then
+                error stop errmsg
+              end if
+
+              spheres % data => null()
+
+            end if
+
+            return
+          end subroutine destructor
+
+      end module sphere
+
+*   OpenBDS                                             October 22, 2023
+*
+*   source: api/fortran/module/sphere/sphere.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Extends the Particle type to define the Sphere type.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.

--- a/api/fortran/test/Makefile
+++ b/api/fortran/test/Makefile
@@ -2,7 +2,7 @@
 #
 # OpenBDS						July 19, 2023
 #
-# source: api/Makefile
+# source: api/fortran/test/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,14 +14,10 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+all: spheres
 
-api-clang:
-	@$(MAKE) -C clang
-
-api-fortran:
-	@$(MAKE) -C fortran
+spheres:
+	@$(MAKE) -C sphere
 
 clean:
-	@$(MAKE) -C clang clean
-	@$(MAKE) -C fortran clean
+	@$(MAKE) -C sphere clean

--- a/api/fortran/test/sphere/Makefile
+++ b/api/fortran/test/sphere/Makefile
@@ -1,0 +1,29 @@
+#!/usr/bin/make
+#
+# OpenBDS						October 22, 2023
+#
+# source: api/fortran/test/sphere/Makefile
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(TEST_SPHERE_BIN)
+
+$(TEST_SPHERE_BIN): $(TEST_SPHERE_O)
+	$(FC) $(FCOPT) $(OBJS) $(TEST_SPHERE_O) -o $(TEST_SPHERE_BIN)
+
+$(TEST_SPHERE_O): $(MODULES) $(OBJS) $(TEST_SPHERE_F)
+	$(FC) $(INC) $(IMODS) $(FCOPT) -ffixed-form -c $(TEST_SPHERE_F) -o\
+		$(TEST_SPHERE_O)
+
+clean:
+	/bin/rm -f *.o *.bin

--- a/api/fortran/test/sphere/make-inc
+++ b/api/fortran/test/sphere/make-inc
@@ -1,0 +1,44 @@
+#
+# OpenBDS					October 22, 2023
+#
+# source: api/fortran/test/sphere/make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+
+# includes
+IMODS = -I../../module/mods
+
+
+# modules
+CONSTANTS_MOD = ../../module/mods/constants.mod
+PARTICLE_MOD  = ../../module/mods/sphere.mod
+
+MODULES = $(CONSTANTS_MOD) $(PARTICLE_MOD)
+
+
+# sources
+TEST_SPHERE_F = tsphere.f
+
+
+# objects
+CONSTANTS_O = ../../module/constants/constants.o
+
+PARTICLE_O = ../../module/particle/particle.o\
+	     ../../module/sphere/sphere.o
+
+OBJS = $(CONSTANTS_O) $(PARTICLE_O)
+
+TEST_SPHERE_O = tsphere.o
+
+
+# binaries
+TEST_SPHERE_BIN = test-sphere.bin

--- a/api/fortran/test/sphere/tsphere.f
+++ b/api/fortran/test/sphere/tsphere.f
@@ -1,0 +1,71 @@
+      program test_sphere_type
+        use, intrinsic :: iso_fortran_env, only: int64
+        use, intrinsic :: iso_fortran_env, only: real64
+        use :: constants, only: NUM_SPHERES => NUM_PARTICLES
+        use :: sphere, only: sphere_t
+        implicit none
+
+c       collection of spheres
+        type(sphere_t), pointer :: spheres => null()
+c       pointer to the particle IDs
+        real(kind = real64), pointer, contiguous :: id(:) => null()
+c       stores the sum of the sequence [1, NUM_SPHERES]
+        integer(kind = int64), parameter :: total =
+     +  NUM_SPHERES * (NUM_SPHERES + 1_int64) / 2_int64
+c       accumulator
+        integer(kind = int64) :: isum = 0_int64
+c       positional index
+        integer(kind = int64) :: i
+
+c       instantiates the collection of spheres:
+        spheres => sphere_t()
+
+c       bindings:
+        id => spheres % id
+
+c       tests:
+        do i = 1, NUM_SPHERES
+          isum = isum + nint(id(i), kind = int64)
+        end do
+
+        write (*, '(A)', advance='no') 'test-sphere[0]: '
+        if (isum /= total) then
+          print *, 'FAIL'
+        else
+          print *, 'PASS'
+        end if
+
+c       call spheres % update()
+
+c       release the memory resources allocated for the spheres
+        deallocate(spheres)
+
+      end program test_sphere_type
+
+*   OpenBDS                                             October 22, 2023
+*
+*   source: api/fortran/test/sphere/tsphere.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Tests the implementation of the sphere type.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.


### PR DESCRIPTION
COMMENTS:
adds initial FORTRAN-based API to OBDS code (as requested by future collaborator)

defines the core particle type and the sphere type

the test checks the assigned particle IDs for correctness