### PR TITLE
updates indentation [FORTRAN]

### DIFF
--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -58,207 +58,207 @@ c           updates the particle positions and orientations
           end subroutine
         end interface
 
-        contains
+      contains
 
-          subroutine iota (x)
-c           Synopsis:
-c           implements a std::iota C++ like method
-c           fills array `x' with values in symmetric range [1, numel]
-            integer(kind = int64), parameter :: numel = NUM_PARTICLES
-            real(kind = real64), intent(out) :: x(numel)
-            integer(kind = int64) :: i
+        subroutine iota (x)
+c         Synopsis:
+c         implements a std::iota C++ like method
+c         fills array `x' with values in symmetric range [1, numel]
+          integer(kind = int64), parameter :: numel = NUM_PARTICLES
+          real(kind = real64), intent(out) :: x(numel)
+          integer(kind = int64) :: i
 
-            do i = 1, numel
-              x(i) = real(i, kind = real64)
-            end do
+          do i = 1, numel
+            x(i) = real(i, kind = real64)
+          end do
 
-            return
-          end subroutine iota
+          return
+        end subroutine iota
 
 
-          subroutine initializer (particles)
-c           Synopsis:
-c           Particles Initializer.
-c           In the Object-Oriented Programming OOP sense this subroutine initializes the
-c           core of the particle objects (though bear in mind that we are handling them
-c           as a collection and not as individual objects so that we can ultimately write
-c           loops in a way that the compiler can optimize them via auto-vectorization).
-c           NOTES:
-c           The constructor of the extending classes must invoke this subroutine, as you
-c           would do in C++ or Java.
-            class(particle_t), intent(inout) :: particles
-            real(kind = real64), pointer, contiguous :: id(:) => null()
-            integer(kind = int64), parameter :: N = NUM_PARTICLES
-c           size position vector
-            integer(kind = int64), parameter :: size_x = N
-            integer(kind = int64), parameter :: size_y = N
-            integer(kind = int64), parameter :: size_z = N
-c           size Verlet displacement vector
-            integer(kind = int64), parameter :: size_Vdx = N
-            integer(kind = int64), parameter :: size_Vdy = N
-            integer(kind = int64), parameter :: size_Vdz = N
-c           size absolute position vector
-            integer(kind = int64), parameter :: size_r_x = N
-            integer(kind = int64), parameter :: size_r_y = N
-            integer(kind = int64), parameter :: size_r_z = N
-c           size Euler angle vector
-            integer(kind = int64), parameter :: size_Eax = N
-            integer(kind = int64), parameter :: size_Eay = N
-            integer(kind = int64), parameter :: size_Eaz = N
-c           size director (or orientation) vector
-            integer(kind = int64), parameter :: size_d_x = N
-            integer(kind = int64), parameter :: size_d_y = N
-            integer(kind = int64), parameter :: size_d_z = N
-c           size force vector
-            integer(kind = int64), parameter :: size_f_x = N
-            integer(kind = int64), parameter :: size_f_y = N
-            integer(kind = int64), parameter :: size_f_z = N
-c           size torque vector
-            integer(kind = int64), parameter :: size_t_x = N
-            integer(kind = int64), parameter :: size_t_y = N
-            integer(kind = int64), parameter :: size_t_z = N
-c           size temporary placeholder
-            integer(kind = int64), parameter :: size_tmp = N
-c           size Verlet neighbor-list (NOTE: we shall allocate more later)
-            integer(kind = int64), parameter :: size_Vnl = N
-c           size particle identifiers IDs
-            integer(kind = int64), parameter :: size_id = N
-c           sizes position vector
-            integer(kind = int64), parameter :: size_data = size_x +
-     +                                                      size_y +
-     +                                                      size_z +
-c           sizes Verlet displacement vector
-     +                                                      size_Vdx +
-     +                                                      size_Vdy +
-     +                                                      size_Vdz +
-c           sizes absolute position vector
-     +                                                      size_r_x +
-     +                                                      size_r_y +
-     +                                                      size_r_z +
-c           sizes Euler angle vector
-     +                                                      size_Eax +
-     +                                                      size_Eay +
-     +                                                      size_Eaz +
-c           sizes director (or orientation) vector
-     +                                                      size_d_x +
-     +                                                      size_d_y +
-     +                                                      size_d_z +
-c           sizes force vector
-     +                                                      size_f_x +
-     +                                                      size_f_y +
-     +                                                      size_f_z +
-c           sizes torque vector
-     +                                                      size_t_x +
-     +                                                      size_t_y +
-     +                                                      size_t_z +
-c           sizes temporary placeholder
-     +                                                      size_tmp +
-c           sizes Verlet neighbor-list
-     +                                                      size_Vnl +
-c           sizes particle identifiers IDs
-     +                                                      size_id
-c           memory allocation status
-            integer(kind = int64) :: mstat
-c           size
-            integer(kind = int64) :: sz
+        subroutine initializer (particles)
+c         Synopsis:
+c         Particles Initializer.
+c         In the Object-Oriented Programming OOP sense this subroutine initializes the
+c         core of the particle objects (though bear in mind that we are handling them
+c         as a collection and not as individual objects so that we can ultimately write
+c         loops in a way that the compiler can optimize them via auto-vectorization).
+c         NOTES:
+c         The constructor of the extending classes must invoke this subroutine, as you
+c         would do in C++ or Java.
+          class(particle_t), intent(inout) :: particles
+          real(kind = real64), pointer, contiguous :: id(:) => null()
+          integer(kind = int64), parameter :: N = NUM_PARTICLES
+c         size position vector
+          integer(kind = int64), parameter :: size_x = N
+          integer(kind = int64), parameter :: size_y = N
+          integer(kind = int64), parameter :: size_z = N
+c         size Verlet displacement vector
+          integer(kind = int64), parameter :: size_Vdx = N
+          integer(kind = int64), parameter :: size_Vdy = N
+          integer(kind = int64), parameter :: size_Vdz = N
+c         size absolute position vector
+          integer(kind = int64), parameter :: size_r_x = N
+          integer(kind = int64), parameter :: size_r_y = N
+          integer(kind = int64), parameter :: size_r_z = N
+c         size Euler angle vector
+          integer(kind = int64), parameter :: size_Eax = N
+          integer(kind = int64), parameter :: size_Eay = N
+          integer(kind = int64), parameter :: size_Eaz = N
+c         size director (or orientation) vector
+          integer(kind = int64), parameter :: size_d_x = N
+          integer(kind = int64), parameter :: size_d_y = N
+          integer(kind = int64), parameter :: size_d_z = N
+c         size force vector
+          integer(kind = int64), parameter :: size_f_x = N
+          integer(kind = int64), parameter :: size_f_y = N
+          integer(kind = int64), parameter :: size_f_z = N
+c         size torque vector
+          integer(kind = int64), parameter :: size_t_x = N
+          integer(kind = int64), parameter :: size_t_y = N
+          integer(kind = int64), parameter :: size_t_z = N
+c         size temporary placeholder
+          integer(kind = int64), parameter :: size_tmp = N
+c         size Verlet neighbor-list (NOTE: we shall allocate more later)
+          integer(kind = int64), parameter :: size_Vnl = N
+c         size particle identifiers IDs
+          integer(kind = int64), parameter :: size_id = N
+c         sizes position vector
+          integer(kind = int64), parameter :: size_data = size_x +
+     +                                                    size_y +
+     +                                                    size_z +
+c         sizes Verlet displacement vector
+     +                                                    size_Vdx +
+     +                                                    size_Vdy +
+     +                                                    size_Vdz +
+c         sizes absolute position vector
+     +                                                    size_r_x +
+     +                                                    size_r_y +
+     +                                                    size_r_z +
+c         sizes Euler angle vector
+     +                                                    size_Eax +
+     +                                                    size_Eay +
+     +                                                    size_Eaz +
+c         sizes director (or orientation) vector
+     +                                                    size_d_x +
+     +                                                    size_d_y +
+     +                                                    size_d_z +
+c         sizes force vector
+     +                                                    size_f_x +
+     +                                                    size_f_y +
+     +                                                    size_f_z +
+c         sizes torque vector
+     +                                                    size_t_x +
+     +                                                    size_t_y +
+     +                                                    size_t_z +
+c         sizes temporary placeholder
+     +                                                    size_tmp +
+c         sizes Verlet neighbor-list
+     +                                                    size_Vnl +
+c         sizes particle identifiers IDs
+     +                                                    size_id
+c         memory allocation status
+          integer(kind = int64) :: mstat
+c         size
+          integer(kind = int64) :: sz
 
-c           allocates memory for the particle data
-            allocate(particles % data(size_data), stat = mstat)
-            if (mstat /= 0_int64) then
-              error stop "particle::initializer(): allocation error"
-            end if
+c         allocates memory for the particle data
+          allocate(particles % data(size_data), stat = mstat)
+          if (mstat /= 0_int64) then
+            error stop "particle::initializer(): allocation error"
+          end if
 
-c           initializes the particle data with zeros
-            particles % data = 0.0_real64
+c         initializes the particle data with zeros
+          particles % data = 0.0_real64
 
-c           position vector binding
-            sz = 0_int64
-            particles % x => particles % data(sz + 1:sz + size_x)
+c         position vector binding
+          sz = 0_int64
+          particles % x => particles % data(sz + 1:sz + size_x)
 
-            sz = sz + size_x
-            particles % y => particles % data(sz + 1:sz + size_y)
+          sz = sz + size_x
+          particles % y => particles % data(sz + 1:sz + size_y)
 
-            sz = sz + size_y
-            particles % z => particles % data(sz + 1:sz + size_z)
+          sz = sz + size_y
+          particles % z => particles % data(sz + 1:sz + size_z)
 
-c           Verlet displacement vector binding
-            sz = sz + size_z
-            particles % Vdx => particles % data(sz + 1:sz + size_Vdx)
+c         Verlet displacement vector binding
+          sz = sz + size_z
+          particles % Vdx => particles % data(sz + 1:sz + size_Vdx)
 
-            sz = sz + size_Vdx
-            particles % Vdy => particles % data(sz + 1:sz + size_Vdy)
+          sz = sz + size_Vdx
+          particles % Vdy => particles % data(sz + 1:sz + size_Vdy)
 
-            sz = sz + size_Vdy
-            particles % Vdz => particles % data(sz + 1:sz + size_Vdz)
+          sz = sz + size_Vdy
+          particles % Vdz => particles % data(sz + 1:sz + size_Vdz)
 
-c           absolute position vector binding
-            sz = sz + size_Vdz
-            particles % r_x => particles % data(sz + 1:sz + size_r_x)
+c         absolute position vector binding
+          sz = sz + size_Vdz
+          particles % r_x => particles % data(sz + 1:sz + size_r_x)
 
-            sz = sz + size_r_x
-            particles % r_y => particles % data(sz + 1:sz + size_r_y)
+          sz = sz + size_r_x
+          particles % r_y => particles % data(sz + 1:sz + size_r_y)
 
-            sz = sz + size_r_y
-            particles % r_z => particles % data(sz + 1:sz + size_r_z)
+          sz = sz + size_r_y
+          particles % r_z => particles % data(sz + 1:sz + size_r_z)
 
-c           Euler angles vector binding
-            sz = sz + size_r_z
-            particles % Eax => particles % data(sz + 1:sz + size_Eax)
+c         Euler angles vector binding
+          sz = sz + size_r_z
+          particles % Eax => particles % data(sz + 1:sz + size_Eax)
 
-            sz = sz + size_Eax
-            particles % Eay => particles % data(sz + 1:sz + size_Eay)
+          sz = sz + size_Eax
+          particles % Eay => particles % data(sz + 1:sz + size_Eay)
 
-            sz = sz + size_Eay
-            particles % Eaz => particles % data(sz + 1:sz + size_Eaz)
+          sz = sz + size_Eay
+          particles % Eaz => particles % data(sz + 1:sz + size_Eaz)
 
-c           director (or orientation) vector binding
-            sz = sz + size_Eaz
-            particles % d_x => particles % data(sz + 1:sz + size_d_x)
+c         director (or orientation) vector binding
+          sz = sz + size_Eaz
+          particles % d_x => particles % data(sz + 1:sz + size_d_x)
 
-            sz = sz + size_d_x
-            particles % d_y => particles % data(sz + 1:sz + size_d_y)
+          sz = sz + size_d_x
+          particles % d_y => particles % data(sz + 1:sz + size_d_y)
 
-            sz = sz + size_d_y
-            particles % d_z => particles % data(sz + 1:sz + size_d_z)
+          sz = sz + size_d_y
+          particles % d_z => particles % data(sz + 1:sz + size_d_z)
 
-c           force vector binding
-            sz = sz + size_d_z
-            particles % f_x => particles % data(sz + 1:sz + size_f_x)
+c         force vector binding
+          sz = sz + size_d_z
+          particles % f_x => particles % data(sz + 1:sz + size_f_x)
 
-            sz = sz + size_f_x
-            particles % f_y => particles % data(sz + 1:sz + size_f_y)
+          sz = sz + size_f_x
+          particles % f_y => particles % data(sz + 1:sz + size_f_y)
 
-            sz = sz + size_f_z
-            particles % f_z => particles % data(sz + 1:sz + size_f_z)
+          sz = sz + size_f_z
+          particles % f_z => particles % data(sz + 1:sz + size_f_z)
 
-c           torque vector binding
-            sz = sz + size_f_z
-            particles % t_x => particles % data(sz + 1:sz + size_t_x)
+c         torque vector binding
+          sz = sz + size_f_z
+          particles % t_x => particles % data(sz + 1:sz + size_t_x)
 
-            sz = sz + size_t_x
-            particles % t_y => particles % data(sz + 1:sz + size_t_y)
+          sz = sz + size_t_x
+          particles % t_y => particles % data(sz + 1:sz + size_t_y)
 
-            sz = sz + size_t_y
-            particles % t_z => particles % data(sz + 1:sz + size_t_z)
+          sz = sz + size_t_y
+          particles % t_z => particles % data(sz + 1:sz + size_t_z)
 
-c           temporary placeholder binding
-            sz = sz + size_t_z
-            particles % tmp => particles % data(sz + 1:sz + size_tmp)
+c         temporary placeholder binding
+          sz = sz + size_t_z
+          particles % tmp => particles % data(sz + 1:sz + size_tmp)
 
-c           Verlet neighbor-list binding
-            sz = sz + size_tmp
-            particles % Vnl => particles % data(sz + 1:sz + size_Vnl)
+c         Verlet neighbor-list binding
+          sz = sz + size_tmp
+          particles % Vnl => particles % data(sz + 1:sz + size_Vnl)
 
-c           particle identifier IDs binding
-            sz = sz + size_Vnl
-            particles % id => particles % data(sz + 1:sz + size_id)
+c         particle identifier IDs binding
+          sz = sz + size_Vnl
+          particles % id => particles % data(sz + 1:sz + size_id)
 
-c           assigns unique IDs to the particles
-            id => particles % id
-            call iota(id)
+c         assigns unique IDs to the particles
+          id => particles % id
+          call iota(id)
 
-            return
-          end subroutine initializer
+          return
+        end subroutine initializer
 
       end module particle
 

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -29,167 +29,167 @@ c       sphere radius, diameter, and contact-distance
           module procedure constructor
         end interface
 
-        contains
+      contains
 
-          subroutine grid (spheres)
-c           Synopsis:
-c           Places the spheres in a grid (or lattice) like structure.
-c           Note:
-c           The intent(in) attribute refers to the pointer only, meaning that the
-c           procedure does not modify its original association; however, the procedure
-c           does modify the position vectors of the spheres.
-            type(sphere_t), pointer, intent(in) :: spheres
-c           pointers to the position vector components
-            real(kind = real64), pointer, contiguous :: x(:) => null()
-            real(kind = real64), pointer, contiguous :: y(:) => null()
-            real(kind = real64), pointer, contiguous :: z(:) => null()
-c           uses offset to ensure no particle overlaps across boundaries
-            real(kind = real64), parameter :: offset = RADIUS
-c           maximum number of spheres that can be stacked in one dimension 1D
-            integer(kind = int64), parameter :: max_num_sph_stacked_1d =
-     +      floor(LENGTH / CONTACT, kind = int64)
-c           maximum number of spheres that can be stacked in two dimensions 2D
-            integer(kind = int64), parameter :: max_num_sph_stacked_2d =
-     +      (max_num_sph_stacked_1d ** 2)
-c           maximum number of spheres that can be stacked in three dimensions 3D
-            integer(kind = int64), parameter :: max_num_sph_stacked_3d =
-     +      (max_num_sph_stacked_1d ** 3)
-c           alias
-            integer(kind = int64), parameter :: stacked_1d =
-     +      max_num_sph_stacked_1d
-c           alias
-            integer(kind = int64), parameter :: stacked_2d =
-     +      max_num_sph_stacked_2d
-c           particle counter
-            integer(kind = int64) :: counter
-c           particle id
-            integer(kind = int64) :: id
-c           index
-            integer(kind = int64) :: i
-c           error message
-            character(*), parameter :: errmsg = "sphere::grid(): "//
-     +      "it is impossible to fit the requested number of spheres "//
-     +      "in a grid (or lattice) like structure without incurring "//
-     +      "in particle overlaps"
+        subroutine grid (spheres)
+c         Synopsis:
+c         Places the spheres in a grid (or lattice) like structure.
+c         Note:
+c         The intent(in) attribute refers to the pointer only, meaning that the
+c         procedure does not modify its original association; however, the procedure
+c         does modify the position vectors of the spheres.
+          type(sphere_t), pointer, intent(in) :: spheres
+c         pointers to the position vector components
+          real(kind = real64), pointer, contiguous :: x(:) => null()
+          real(kind = real64), pointer, contiguous :: y(:) => null()
+          real(kind = real64), pointer, contiguous :: z(:) => null()
+c         uses offset to ensure no particle overlaps across boundaries
+          real(kind = real64), parameter :: offset = RADIUS
+c         maximum number of spheres that can be stacked in one dimension 1D
+          integer(kind = int64), parameter :: max_num_sph_stacked_1d =
+     +    floor(LENGTH / CONTACT, kind = int64)
+c         maximum number of spheres that can be stacked in two dimensions 2D
+          integer(kind = int64), parameter :: max_num_sph_stacked_2d =
+     +    (max_num_sph_stacked_1d ** 2)
+c         maximum number of spheres that can be stacked in three dimensions 3D
+          integer(kind = int64), parameter :: max_num_sph_stacked_3d =
+     +    (max_num_sph_stacked_1d ** 3)
+c         alias
+          integer(kind = int64), parameter :: stacked_1d =
+     +    max_num_sph_stacked_1d
+c         alias
+          integer(kind = int64), parameter :: stacked_2d =
+     +    max_num_sph_stacked_2d
+c         particle counter
+          integer(kind = int64) :: counter
+c         particle id
+          integer(kind = int64) :: id
+c         index
+          integer(kind = int64) :: i
+c         error message
+          character(*), parameter :: errmsg = "sphere::grid(): "//
+     +    "it is impossible to fit the requested number of spheres "//
+     +    "in a grid (or lattice) like structure without incurring "//
+     +    "in particle overlaps"
 
-c           complains if it is not possible to place the particles in the grid-like
-c           structure implemented by this procedure
-            if (NUM_SPHERES > max_num_sph_stacked_3d) then
+c         complains if it is not possible to place the particles in the grid-like
+c         structure implemented by this procedure
+          if (NUM_SPHERES > max_num_sph_stacked_3d) then
+            error stop errmsg
+          end if
+
+          x => spheres % x
+
+          counter = 0_int64
+c         loop-invariant: so far we have updated the `x' position of `counter' spheres
+c         NOTE:
+c         stacks a pile of spheres (at contact) along the x-dimension; the `x'
+c         coordinates increment on each iteration until a pile is completed, and in
+c         that instance the `x' coordinate is reseted to zero.
+          do while (counter /= NUM_SPHERES)
+            id = counter + 1_int64
+            i = mod(counter, max_num_sph_stacked_1d)
+            x(id) = offset + CONTACT * real(i, kind = real64)
+            counter = counter + 1_int64
+          end do
+
+c         adjusts `x'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
+          x = x - LIMIT
+
+          y => spheres % y
+
+          counter = 0_int64
+c         loop-invariant: so far we have updated the `y' position of `counter' spheres
+c         NOTE:
+c         The `y' coordinates increment when a pile is completed, the `y' coordinate
+c         gets reseted upon filling an entire area (in the x-y plane).
+          do while (counter /= NUM_SPHERES)
+            id = counter + 1_int64
+            i = mod(counter, stacked_2d) / stacked_1d
+            y(id) = offset + CONTACT * real(i, kind = real64)
+            counter = counter + 1_int64
+          end do
+
+c         adjusts the `y'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
+          y = y - LIMIT
+
+          z => spheres % z
+
+          counter = 0_int64
+c         loop-invariant: so far we have updated the `z' position of `counter' spheres
+c         NOTE: The `z' coordinates increment upon filling an area (in the x-y plane).
+          do while (counter /= NUM_SPHERES)
+            id = counter + 1_int64
+            i = counter / max_num_sph_stacked_2d
+            z(id) = offset + CONTACT * real(i, kind = real64)
+            counter = counter + 1_int64
+          end do
+
+c         adjusts the `z'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
+          z = z - LIMIT
+
+          return
+        end subroutine grid
+
+
+        function constructor () result(spheres)
+c         Synopsis:
+c         Allocates resources and initializes the spheres.
+          type(sphere_t), pointer :: spheres
+          integer(kind = int64) :: mstat
+
+c         memory allocations:
+          spheres => null()
+          allocate(spheres, stat = mstat)
+          if (mstat /= 0_int64) then
+            error stop "sphere_t(): memory allocation error"
+          end if
+
+c         initializations:
+          call spheres % initialize()
+
+c         places the spheres in a grid (or lattice) like structure
+          call grid(spheres)
+
+          return
+        end function constructor
+
+
+        subroutine updater (particles)
+c         Synopsis:
+c         Initial implementation so that the compiler won't complain.
+          class(sphere_t), intent(inout) :: particles
+
+          print *, 'sphere::update(): unimplemented'
+          print *, minval(particles % id)
+          print *, maxval(particles % id)
+
+          return
+        end subroutine updater
+
+
+        subroutine destructor (spheres)
+c         Synopsis:
+c         Frees resources allocated for the spheres.
+          type(sphere_t), intent(inout) :: spheres
+          integer(kind = int64) :: mstat
+          character(*), parameter :: errmsg =
+     +    "sphere::destructor(): unexpected memory deallocation error"
+
+          if ( associated(spheres % data) ) then
+
+            deallocate(spheres % data, stat = mstat)
+
+            if (mstat /= 0_int64) then
               error stop errmsg
             end if
 
-            x => spheres % x
+            spheres % data => null()
 
-            counter = 0_int64
-c           loop-invariant: so far we have updated the `x' position of `counter' spheres
-c           NOTE:
-c           stacks a pile of spheres (at contact) along the x-dimension; the `x'
-c           coordinates increment on each iteration until a pile is completed, and in
-c           that instance the `x' coordinate is reseted to zero.
-            do while (counter /= NUM_SPHERES)
-              id = counter + 1_int64
-              i = mod(counter, max_num_sph_stacked_1d)
-              x(id) = offset + CONTACT * real(i, kind = real64)
-              counter = counter + 1_int64
-            end do
+          end if
 
-c           adjusts `x'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
-            x = x - LIMIT
-
-            y => spheres % y
-
-            counter = 0_int64
-c           loop-invariant: so far we have updated the `y' position of `counter' spheres
-c           NOTE:
-c           The `y' coordinates increment when a pile is completed, the `y' coordinate
-c           gets reseted upon filling an entire area (in the x-y plane).
-            do while (counter /= NUM_SPHERES)
-              id = counter + 1_int64
-              i = mod(counter, stacked_2d) / stacked_1d
-              y(id) = offset + CONTACT * real(i, kind = real64)
-              counter = counter + 1_int64
-            end do
-
-c           adjusts the `y'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
-            y = y - LIMIT
-
-            z => spheres % z
-
-            counter = 0_int64
-c           loop-invariant: so far we have updated the `z' position of `counter' spheres
-c           NOTE: The `z' coordinates increment upon filling an area (in the x-y plane).
-            do while (counter /= NUM_SPHERES)
-              id = counter + 1_int64
-              i = counter / max_num_sph_stacked_2d
-              z(id) = offset + CONTACT * real(i, kind = real64)
-              counter = counter + 1_int64
-            end do
-
-c           adjusts the `z'-coordinates so that they fall in the range [-LIMIT, +LIMIT]
-            z = z - LIMIT
-
-            return
-          end subroutine grid
-
-
-          function constructor () result(spheres)
-c           Synopsis:
-c           Allocates resources and initializes the spheres.
-            type(sphere_t), pointer :: spheres
-            integer(kind = int64) :: mstat
-
-c           memory allocations:
-            spheres => null()
-            allocate(spheres, stat = mstat)
-            if (mstat /= 0_int64) then
-              error stop "sphere_t(): memory allocation error"
-            end if
-
-c           initializations:
-            call spheres % initialize()
-
-c           places the spheres in a grid (or lattice) like structure
-            call grid(spheres)
-
-            return
-          end function constructor
-
-
-          subroutine updater (particles)
-c           Synopsis:
-c           Initial implementation so that the compiler won't complain.
-            class(sphere_t), intent(inout) :: particles
-
-            print *, 'sphere::update(): unimplemented'
-            print *, minval(particles % id)
-            print *, maxval(particles % id)
-
-            return
-          end subroutine updater
-
-
-          subroutine destructor (spheres)
-c           Synopsis:
-c           Frees resources allocated for the spheres.
-            type(sphere_t), intent(inout) :: spheres
-            integer(kind = int64) :: mstat
-            character(*), parameter :: errmsg =
-     +      "sphere::destructor(): unexpected memory deallocation error"
-
-            if ( associated(spheres % data) ) then
-
-              deallocate(spheres % data, stat = mstat)
-
-              if (mstat /= 0_int64) then
-                error stop errmsg
-              end if
-
-              spheres % data => null()
-
-            end if
-
-            return
-          end subroutine destructor
+          return
+        end subroutine destructor
 
       end module sphere
 


### PR DESCRIPTION
this is so what we can get two more columns to write code in module subroutines (we are using fixed-source style so this matters)

we used regular expressions such as these in `vi` to change the indentation (just removes two spaces while keeping the rest of the matched string untouched)

```
%s/\(^c\s\+\)  /\1/gc
```