### PR TITLE
uses overloaded intrinsics [FORTRAN]

### DIFF
--- a/api/fortran/module/dynamic/dynamic.f
+++ b/api/fortran/module/dynamic/dynamic.f
@@ -74,7 +74,7 @@ c         with a callback, as in the clang API, to handle anisotropic particles.
           real(kind = real64), pointer, contiguous :: F_x(:) => null()
           real(kind = real64), pointer, contiguous :: F_y(:) => null()
           real(kind = real64), pointer, contiguous :: F_z(:) => null()
-          real(kind = real64), parameter :: m = dsqrt(2.0_real64 * dt)
+          real(kind = real64), parameter :: m = sqrt(2.0_real64 * dt)
           real(kind = real64), parameter :: mobility = m
 
           F_x => particles % F_x

--- a/api/fortran/module/random/random.f
+++ b/api/fortran/module/random/random.f
@@ -51,7 +51,7 @@ c         is equal to zero that means that furand()'s underlying PRNG is bogus.
 
           end do
 
-          r = dsqrt( ( -2.0_real64 * dlog(r) ) / r )
+          r = sqrt( ( -2.0_real64 * log(r) ) / r )
 
           x1 = r * x1
           x2 = r * x2


### PR DESCRIPTION
COMMENTS:
the return type of these functions is the same as the argument so there's no loss in precision