### PR TITLE
adds non-interacting Brownian spheres [FORTRAN]

### DIFF
--- a/api/fortran/module/Makefile
+++ b/api/fortran/module/Makefile
@@ -25,10 +25,10 @@ PRNGs:
 particles: constants
 	@$(MAKE) -C particle
 
-forces: constants PRNGs
+forces: particles PRNGs
 	@$(MAKE) -C force
 
-dynamics: forces particles
+dynamics: forces
 	@$(MAKE) -C dynamic
 
 spheres: dynamics

--- a/api/fortran/module/force/force.f
+++ b/api/fortran/module/force/force.f
@@ -1,13 +1,14 @@
       module force
         use, intrinsic :: iso_fortran_env, only: real64
         use :: constant, only: N => NUM_PARTICLES
+        use :: particle, only: particle_t
         use :: random, only: fnrand
         implicit none
         private
         public :: force__Brownian_force
 
         interface force__Brownian_force
-          module procedure Brownian_force
+          module procedure Brownian_force_base
         end interface
 
       contains
@@ -37,6 +38,24 @@ c         Fills the Brownian forces with normally distributed pseudo-random numb
 
           return
         end subroutine Brownian_force
+
+
+        subroutine Brownian_force_base (particles)
+c         Synopsis:
+c         Updates the force vectors with the Brownian forces.
+          class(particle_t), intent(inout) :: particles
+          real(kind = real64), pointer, contiguous :: F_x(:) => null()
+          real(kind = real64), pointer, contiguous :: F_y(:) => null()
+          real(kind = real64), pointer, contiguous :: F_z(:) => null()
+
+          F_x => particles % F_x
+          F_y => particles % F_y
+          F_z => particles % F_z
+
+          call Brownian_force(F_x, F_y, F_z)
+
+          return
+        end subroutine Brownian_force_base
 
       end module force
 

--- a/api/fortran/module/force/make-inc
+++ b/api/fortran/module/force/make-inc
@@ -16,7 +16,8 @@
 # modules
 CONSTANT_MOD = ../mods/constant.mod
 RANDOM_MOD = ../mods/random.mod
-MODULES = $(CONSTANT_MOD) $(RANDOM_MOD)
+PARTICLE_MOD = ../mods/particle.mod
+MODULES = $(CONSTANT_MOD) $(RANDOM_MOD) $(PARTICLE_MOD)
 
 # sources
 FORCE_F = force.f

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -4,6 +4,8 @@
         use :: constant, only: LIMIT
         use :: constant, only: LENGTH
         use :: constant, only: NUM_SPHERES => NUM_PARTICLES
+        use :: force, only: force__Brownian_force
+        use :: dynamic, only: dynamic__shifter
         use :: particle, only: particle_t
         implicit none
         private
@@ -157,12 +159,11 @@ c         places the spheres in a grid (or lattice) like structure
 
         subroutine updater (particles)
 c         Synopsis:
-c         Initial implementation so that the compiler won't complain.
+c         Implements non-interacting Brownian spheres.
           class(sphere_t), intent(inout) :: particles
 
-          print *, 'sphere::update(): unimplemented'
-          print *, minval(particles % id)
-          print *, maxval(particles % id)
+          call force__Brownian_force(particles)
+          call dynamic__shifter(particles)
 
           return
         end subroutine updater

--- a/api/fortran/test/sphere/make-inc
+++ b/api/fortran/test/sphere/make-inc
@@ -32,10 +32,16 @@ TEST_SPHERE_F = tsphere.f
 # objects
 CONSTANTS_O = ../../module/constant/constant.o
 
+RANDOM_O    = ../../module/random/random.o
+
 PARTICLE_O = ../../module/particle/particle.o\
 	     ../../module/sphere/sphere.o
 
-OBJS = $(CONSTANTS_O) $(PARTICLE_O)
+FORCE_O     = ../../module/force/force.o
+
+DYNAMIC_O   = ../../module/dynamic/dynamic.o
+
+OBJS = $(CONSTANTS_O) $(RANDOM_O) $(PARTICLE_O) $(FORCE_O) $(DYNAMIC_O)
 
 TEST_SPHERE_O = tsphere.o
 


### PR DESCRIPTION
COMMENTS:
updates the implementation of `sphere::updater()`