### PR TITLE
updates makefiles for GFORTRAN and IFORT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,18 @@
 
 include make-inc
 
+# sets the module flag according to the FORTRAN Compiler FC
+ifeq ($(FC), ifort)
+	FMOD = -module
+else
+	FMOD = -J
+endif
+
 export CC
 export FC
 export CCOPT
 export FCOPT
+export FMOD
 export LIBS
 
 all: apis

--- a/api/Makefile
+++ b/api/Makefile
@@ -14,7 +14,8 @@
 # (at your option) any later version.
 #
 
-all: api-clang api-fortran
+#all: api-clang api-fortran
+all: api-fortran
 
 api-clang:
 	@$(MAKE) -C clang

--- a/api/fortran/module/Makefile
+++ b/api/fortran/module/Makefile
@@ -45,4 +45,4 @@ clean:
 	@$(MAKE) -C force clean
 	@$(MAKE) -C dynamic clean
 	@$(MAKE) -C sphere clean
-	rm mods/*.mod
+	rm -f mods/*.mod

--- a/api/fortran/module/constant/Makefile
+++ b/api/fortran/module/constant/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(CONSTANTS_O)
 
 $(CONSTANTS_O): $(CONSTANTS_F)
-	$(FC) $(FCOPT) -c $(CONSTANTS_F) -o $(CONSTANTS_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(CONSTANTS_F) -o $(CONSTANTS_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/constant/Makefile
+++ b/api/fortran/module/constant/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(CONSTANTS_O)
 
 $(CONSTANTS_O): $(CONSTANTS_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(CONSTANTS_F) -o $(CONSTANTS_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(CONSTANTS_F) -o $(CONSTANTS_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/dynamic/Makefile
+++ b/api/fortran/module/dynamic/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(DYNAMIC_O)
 
 $(DYNAMIC_O): $(MODULES) $(DYNAMIC_F)
-	$(FC) $(FCOPT) -c $(DYNAMIC_F) -o $(DYNAMIC_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(DYNAMIC_F) -o $(DYNAMIC_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/dynamic/Makefile
+++ b/api/fortran/module/dynamic/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(DYNAMIC_O)
 
 $(DYNAMIC_O): $(MODULES) $(DYNAMIC_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(DYNAMIC_F) -o $(DYNAMIC_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(DYNAMIC_F) -o $(DYNAMIC_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/force/Makefile
+++ b/api/fortran/module/force/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(FORCE_O)
 
 $(FORCE_O): $(MODULES) $(FORCE_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(FORCE_F) -o $(FORCE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(FORCE_F) -o $(FORCE_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/force/Makefile
+++ b/api/fortran/module/force/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(FORCE_O)
 
 $(FORCE_O): $(MODULES) $(FORCE_F)
-	$(FC) $(FCOPT) -c $(FORCE_F) -o $(FORCE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(FORCE_F) -o $(FORCE_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/particle/Makefile
+++ b/api/fortran/module/particle/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(PARTICLE_O)
 
 $(PARTICLE_O): $(MODULES) $(PARTICLE_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(PARTICLE_F) -o $(PARTICLE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(PARTICLE_F) -o $(PARTICLE_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/particle/Makefile
+++ b/api/fortran/module/particle/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(PARTICLE_O)
 
 $(PARTICLE_O): $(MODULES) $(PARTICLE_F)
-	$(FC) $(FCOPT) -c $(PARTICLE_F) -o $(PARTICLE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(PARTICLE_F) -o $(PARTICLE_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -44,7 +44,8 @@ c         data placeholder
           real(kind = real64), pointer, contiguous :: data(:) => null()
           contains
             private
-            procedure :: initializer    ! memory allocations and initializations
+c           memory allocations and initializations
+            procedure :: initializer
 c           bindings:
             procedure, public :: initialize => initializer
 c           updates the particle positions and orientations

--- a/api/fortran/module/random/Makefile
+++ b/api/fortran/module/random/Makefile
@@ -19,8 +19,7 @@ include make-inc
 all: $(RANDOM_O)
 
 $(RANDOM_O): $(RANDOM_F)
-	$(FC) $(FCOPT) -ffixed-form -Wno-compare-reals -c $(RANDOM_F) -o\
-		$(RANDOM_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(RANDOM_F) -o $(RANDOM_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/random/Makefile
+++ b/api/fortran/module/random/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(RANDOM_O)
 
 $(RANDOM_O): $(RANDOM_F)
-	$(FC) $(FCOPT) -c $(RANDOM_F) -o $(RANDOM_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(RANDOM_F) -o $(RANDOM_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/sphere/Makefile
+++ b/api/fortran/module/sphere/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(SPHERE_O)
 
 $(SPHERE_O): $(MODULES) $(SPHERE_F)
-	$(FC) $(FCOPT) -c $(SPHERE_F) -o $(SPHERE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(SPHERE_F) -o $(SPHERE_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/sphere/Makefile
+++ b/api/fortran/module/sphere/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(SPHERE_O)
 
 $(SPHERE_O): $(MODULES) $(SPHERE_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(SPHERE_F) -o $(SPHERE_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(SPHERE_F) -o $(SPHERE_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -163,9 +163,12 @@ c         Synopsis:
 c         Implements non-interacting Brownian spheres.
           class(sphere_t), intent(inout) :: particles
 
-          call force__Brownian_force(particles) ! computes Brownian forces
-          call dynamic__shifter(particles)      ! shifts particles Brownianly
-          call system__PBC(particles)           ! applies Periodic Boundary Conditions
+c         computes Brownian forces
+          call force__Brownian_force(particles)
+c         shifts particles Brownianly
+          call dynamic__shifter(particles)
+c         applies Periodic Boundary Conditions
+          call system__PBC(particles)
 
           return
         end subroutine updater

--- a/api/fortran/module/system/Makefile
+++ b/api/fortran/module/system/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(SYSTEM_O)
 
 $(SYSTEM_O): $(MODULES) $(SYSTEM_F)
-	$(FC) $(FCOPT) -ffixed-form -c $(SYSTEM_F) -o $(SYSTEM_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(SYSTEM_F) -o $(SYSTEM_O) -J $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/module/system/Makefile
+++ b/api/fortran/module/system/Makefile
@@ -19,7 +19,7 @@ include make-inc
 all: $(SYSTEM_O)
 
 $(SYSTEM_O): $(MODULES) $(SYSTEM_F)
-	$(FC) $(FCOPT) -c $(SYSTEM_F) -o $(SYSTEM_O) -J $(MODS)
+	$(FC) $(FCOPT) -c $(SYSTEM_F) -o $(SYSTEM_O) $(FMOD) $(MODS)
 
 clean:
 	/bin/rm -f *.o

--- a/api/fortran/test/sphere/Makefile
+++ b/api/fortran/test/sphere/Makefile
@@ -22,8 +22,7 @@ $(TEST_SPHERE_BIN): $(TEST_SPHERE_O)
 	$(FC) $(FCOPT) $(OBJS) $(TEST_SPHERE_O) -o $(TEST_SPHERE_BIN)
 
 $(TEST_SPHERE_O): $(MODULES) $(OBJS) $(TEST_SPHERE_F)
-	$(FC) $(INC) $(IMODS) $(FCOPT) -ffixed-form -c $(TEST_SPHERE_F) -o\
-		$(TEST_SPHERE_O)
+	$(FC) $(INC) $(IMODS) $(FCOPT) -c $(TEST_SPHERE_F) -o $(TEST_SPHERE_O)
 
 clean:
 	/bin/rm -f *.o *.bin

--- a/make-inc
+++ b/make-inc
@@ -34,16 +34,14 @@ CC = gcc-9
 CC = gcc
 
 # MAC OS X Intel FORTRAN Compiler Options
-FCOPT = -cpp -free -warn all -g -O0
+FCOPT = -cpp -fixed -warn all -g -O0
 # Linux GNU FORTRAN Compiler Options
-FCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffree-form\
-	-ffree-line-length-none
-FCOPT = -O2 -mavx -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffree-form\
-	-ffree-line-length-none
+FCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form
+FCOPT = -O2 -mavx -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form
 FCOPT = -g -Wall -Wextra -Waliasing -Wsurprising -Warray-bounds -Warray-temporaries\
 	-Wcharacter-truncation -Wconversion-extra -Wimplicit-interface\
 	-Wimplicit-procedure -Wuse-without-only -Wrealloc-lhs -Wrealloc-lhs-all\
-	-fcheck=all -O0 -cpp -ffree-form -ffree-line-length-none
+	-fcheck=all -O0 -cpp -ffixed-form
 
 # clang options
 # MAC OS X Intel C Compiler Options


### PR DESCRIPTION
updates the makefiles so that these can be used regardless of the FORTRAN compiler being used; thus far we have added code to support compilation with the GNU and Intel FORTRAN compilers

we have disabled compilation of the clang-based API but only for a short period of time