### PR TITLE
uses FORTRAN free source formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,17 @@ else
 	FMOD = -J
 endif
 
+ifeq ($(FC), ifort)
+	FFREE = -free
+else
+	FFREE = -ffree-form -ffree-line-length-none
+endif
+
 export CC
 export FC
 export CCOPT
 export FCOPT
+export FFREE
 export FMOD
 export LIBS
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -14,8 +14,7 @@
 # (at your option) any later version.
 #
 
-#all: api-clang api-fortran
-all: api-fortran
+all: api-clang api-fortran
 
 api-clang:
 	@$(MAKE) -C clang

--- a/api/clang/src/bds/fortran/Makefile
+++ b/api/clang/src/bds/fortran/Makefile
@@ -23,7 +23,7 @@ $(OBDS): $(OBDS_O)
 
 
 $(OBDS_O): $(DEPS_O) $(OBDS_F)
-	$(FC) $(INC) $(FCOPT) -c $(OBDS_F) -o $(OBDS_O)
+	$(FC) $(INC) $(FCOPT) $(FFREE) -c $(OBDS_F) -o $(OBDS_O)
 
 clean:
 	/bin/rm -f *.o *.log *.mod *.bin

--- a/api/clang/src/test/particle-sphere/Makefile
+++ b/api/clang/src/test/particle-sphere/Makefile
@@ -28,7 +28,7 @@ $(TEST_O): $(DEPS_O) $(TEST_C)
 	$(CC) $(INC) $(CCOPT) -c $(TEST_C) -o $(TEST_O)
 
 $(FEST_O): $(DEPS_O) $(TEST_F)
-	$(FC) $(INC) $(FCOPT) -c $(TEST_F) -o $(FEST_O)
+	$(FC) $(INC) $(FCOPT) $(FFREE) -c $(TEST_F) -o $(FEST_O)
 
 clean:
 	/bin/rm -f *.o *.log *.mod *.bin


### PR DESCRIPTION
COMMENTS:
uses FORTRAN free source formatting in FORTRAN source files nested in the clang-based API

restores the clang-based API!