### PR TITLE
revises code to compile with ICX [clang]

### DIFF
--- a/api/clang/src/io/logger/logger.c
+++ b/api/clang/src/io/logger/logger.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>

--- a/api/clang/src/particle/sphere/sphere.c
+++ b/api/clang/src/particle/sphere/sphere.c
@@ -878,9 +878,9 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
   // compile-time sane checks:
 
 #if ( ( __GNUC__ > 12 ) && ( __STDC_VERSION__ > STDC17 ) )
-  static_assert(BYTE_ORDER == LITTLE_ENDIAN);
-#if defined(FLOAT_WORD_ORDER)
-  static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN);
+  static_assert(__BYTE_ORDER == __LITTLE_ENDIAN);
+#if defined(__FLOAT_WORD_ORDER)
+  static_assert(__FLOAT_WORD_ORDER == __LITTLE_ENDIAN);
 #endif
   // this assertion shall be removed once we add minimal code for anisotropic particles
   static_assert( __OBDS_SPH__ );
@@ -904,9 +904,10 @@ sphere_t* particles_sphere_initializer (void* workspace, SPHLOG LVL)
   static_assert(CONTACT == 2.0);
   static_assert(RADIUS == 1.0);
 #else
-  _Static_assert(BYTE_ORDER == LITTLE_ENDIAN, "expects little-endian byte-order");
-#if defined(FLOAT_WORD_ORDER)
-  _Static_assert(FLOAT_WORD_ORDER == LITTLE_ENDIAN, "expects little-endian byte-order");
+  _Static_assert(__BYTE_ORDER == __LITTLE_ENDIAN, "expects little-endian byte-order");
+#if defined(__FLOAT_WORD_ORDER)
+  _Static_assert(__FLOAT_WORD_ORDER == __LITTLE_ENDIAN,
+		 "expects little-endian byte-order");
 #endif
   // this assertion shall be removed once we add minimal code for anisotropic particles
   _Static_assert( __OBDS_SPH__, "configuration error, non-isotropic resistance" );

--- a/api/clang/src/util/random/random.c
+++ b/api/clang/src/util/random/random.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <fcntl.h>	// for reading /dev/urandom
 #include <sys/stat.h>	// for reading /dev/urandom
 #include <sys/types.h>	// required by getpid(), see man getpid

--- a/make-inc
+++ b/make-inc
@@ -24,7 +24,7 @@ FC = gfortran
 
 # clang compilers
 # Intel C Compiler
-CC = icc
+CC = icx
 # Linux LLVM C Compiler (clang) Options
 CC = clang-12
 # GNU C Compiler


### PR DESCRIPTION
COMMENTS:
defines _XOPEN_SOURCE 700 to be able to use `srandom()`, `random()`, `mkstemp()`, etc.

uses leading double underscores in MACROS defined by `endian.h` so that the Intel C Compiler succeeds in compiling the source code. This is a quick fix, I am certain that there other ways to do this that can be used later (if really needed).

Note that Intel has deprecated ICC `icc`, now we have to use `icx`