### PR TITLE
applies good programming practices [FORTRAN]

### DIFF
--- a/api/fortran/module/constant/constant.f
+++ b/api/fortran/module/constant/constant.f
@@ -8,13 +8,25 @@
         public :: LENGTH
         public :: TIME_STEP
         public :: NUM_PARTICLES
+        public :: LOG_NUM_PARTICLES
 
 c       system box limits and length
         real(kind = real64), parameter :: LIMIT = 8.0_real64
         real(kind = real64), parameter :: LENGTH = (2.0_real64 * LIMIT)
 c       OBDS time-step
         real(kind = real64), parameter :: TIME_STEP = 2.0_real64**(-16)
-        integer(kind = int64), parameter :: NUM_PARTICLES = 256_int64
+c       stores log base two of N, log2(N), where `N' is the number of particles
+        integer(kind = int64), parameter :: LOG_NUM_PARTICLES = 8_int64
+c       defines the number of particles in the system (expressed as a power of two)
+c       NOTE:
+c       The number of particles is a power of two by design. Some of the algorithms that
+c       will be implemented expect the number of particles to be expressible exactly as a
+c       power of two. Change this design constraint only if you know what you are doing.
+c       If all that you want is to achieve a certain volume fraction that can be done more
+c       easily by adjusting the system LIMIT. We use constants that can be expressed
+c       as powers of two because these have exact binary floating-point representations.
+        integer(kind = int64), parameter :: NUM_PARTICLES =
+     +  2_int64 ** LOG_NUM_PARTICLES
 
       end module constant
 

--- a/api/fortran/module/dynamic/dynamic.f
+++ b/api/fortran/module/dynamic/dynamic.f
@@ -34,7 +34,7 @@ c         Shifts the particles position by the action of the Brownian forces.
 c         NOTE:
 c         This code only applies to spheres. We shall overload this method later
 c         with a callback, as in the clang API, to handle anisotropic particles.
-          class(particle_t), intent(inout) :: particles
+          class(particle_t), intent(inout), target :: particles
           real(kind = real64), pointer, contiguous :: x(:) => null()
           real(kind = real64), pointer, contiguous :: y(:) => null()
           real(kind = real64), pointer, contiguous :: z(:) => null()

--- a/api/fortran/module/force/force.f
+++ b/api/fortran/module/force/force.f
@@ -43,7 +43,7 @@ c         Fills the Brownian forces with normally distributed pseudo-random numb
         subroutine Brownian_force_base (particles)
 c         Synopsis:
 c         Updates the force vectors with the Brownian forces.
-          class(particle_t), intent(inout) :: particles
+          class(particle_t), intent(inout), target :: particles
           real(kind = real64), pointer, contiguous :: F_x(:) => null()
           real(kind = real64), pointer, contiguous :: F_y(:) => null()
           real(kind = real64), pointer, contiguous :: F_z(:) => null()

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -1,6 +1,7 @@
       module particle
         use, intrinsic :: iso_fortran_env, only: int64
         use, intrinsic :: iso_fortran_env, only: real64
+        use :: constant, only: LOG_NUM_PARTICLES
         use :: constant, only: NUM_PARTICLES
         implicit none
         private
@@ -90,6 +91,9 @@ c         would do in C++ or Java.
           class(particle_t), intent(inout) :: particles
           real(kind = real64), pointer, contiguous :: id(:) => null()
           integer(kind = int64), parameter :: N = NUM_PARTICLES
+          integer(kind = int64), parameter :: LOG_N = LOG_NUM_PARTICLES
+          logical(kind = int64), parameter :: sane =
+     +    (N == 2_int64 ** LOG_N)
 c         size position vector
           integer(kind = int64), parameter :: size_x = N
           integer(kind = int64), parameter :: size_y = N
@@ -162,6 +166,13 @@ c         memory allocation status
           integer(kind = int64) :: mstat
 c         size
           integer(kind = int64) :: sz
+
+c         complains if someone changes the design in module `constant'
+          if (.not. sane) then
+            error stop "particle::initializer(): " //
+     +                 "IllegalParameterError: the number of " //
+     +                 "particles is not a power of two"
+          end if
 
 c         allocates memory for the particle data
           allocate(particles % data(size_data), stat = mstat)

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -52,7 +52,7 @@ c           updates the particle positions and orientations
             procedure(iupdate), deferred, public :: update
         end type particle_t
 
-        interface
+        abstract interface
           subroutine iupdate (particles)
             import particle_t
             class(particle_t), intent(inout) :: particles

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -138,6 +138,19 @@ c         adjusts the `z'-coordinates so that they fall in the range [-LIMIT, +L
         function constructor () result(spheres)
 c         Synopsis:
 c         Allocates resources and initializes the spheres.
+c         NOTE:
+c         We return a pointer so that we won't need to implement the assigment operator
+c         while still being able to express the instantiation in a Python-like fashion.
+c         (If that's not the reason why the FORTRAN standard has enabled us to do things
+c         as such, then we don't know what is.) We can afford to return a pointer despite
+c         all the advice against the use of pointers in FORTRAN because instantiation
+c         only happens once, and even if the pointer association `=>' is mistaken in the
+c         future with assignment `=' we would know that replacing the assignment operator
+c         with pointer association will fix that bug. We don't like the idea of relying
+c         on the assignment operator that the FORTRAN compiler can synthesize (have done
+c         that and have regretted all the time spent trying to figure out why it does not
+c         work and how to fix it). We are open to reconsider our position if the standard
+c         provides a better solution than our workaround in the future.
           type(sphere_t), pointer :: spheres
           integer(kind = int64) :: mstat
 


### PR DESCRIPTION
- adds some sane checks
- adds some notes for the developer explaining the why not just stating what's being done
- applies [good](https://fortran-lang.org/en/learn/best_practices/) programming practices in the FORTRAN language