### PR TITLE
fixes potential memory leaks [FORTRAN]

### DIFF
--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -62,6 +62,13 @@ c         error message
         end subroutine stackable
 
 
+        subroutine sane ()
+c         complains if it is not possible to stack the spheres in a grid-like fashion
+          call stackable()
+          return
+        end subroutine sane
+
+
         pure subroutine stack_x (x)
 c         Synopsis:
 c         Sets the `x'-coordinates of the spheres so that they are stacked in 1D.
@@ -201,9 +208,6 @@ c         pointers to the position vector components
           real(kind = real64), pointer, contiguous :: y(:) => null()
           real(kind = real64), pointer, contiguous :: z(:) => null()
 
-c         complains if it is not possible to stack the spheres in a grid-like fashion
-          call stackable()
-
           x => spheres % x
 
 c         stacks a pile of spheres (at contact) along the x-dimension
@@ -250,6 +254,9 @@ c         work and how to fix it). We are open to reconsider our position if the
 c         provides a better solution than our workaround in the future.
           type(sphere_t), pointer :: spheres
           integer(kind = int64) :: mstat
+
+c         performs sane-checks
+          call sane()
 
 c         memory allocations:
           spheres => null()

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -63,8 +63,12 @@ c         error message
 
 
         subroutine sane ()
+c         Synopsis:
+c         Performs runtime sane checks.
+
 c         complains if it is not possible to stack the spheres in a grid-like fashion
           call stackable()
+
           return
         end subroutine sane
 
@@ -195,18 +199,14 @@ c         loop-invariant: so far we have updated the `z' position of `counter' s
         end subroutine stack_z
 
 
-        subroutine grid (spheres)
+        pure subroutine grid (spheres)
 c         Synopsis:
 c         Places the spheres in a grid (or lattice) like structure.
-c         Note:
-c         The intent(in) attribute refers to the pointer only, meaning that the
-c         procedure does not modify its original association; however, the procedure
-c         does modify the position vectors of the spheres.
-          type(sphere_t), pointer, intent(in) :: spheres
+          type(sphere_t), target, intent(inout) :: spheres
 c         pointers to the position vector components
-          real(kind = real64), pointer, contiguous :: x(:) => null()
-          real(kind = real64), pointer, contiguous :: y(:) => null()
-          real(kind = real64), pointer, contiguous :: z(:) => null()
+          real(kind = real64), pointer, contiguous :: x(:)
+          real(kind = real64), pointer, contiguous :: y(:)
+          real(kind = real64), pointer, contiguous :: z(:)
 
           x => spheres % x
 


### PR DESCRIPTION
- performs runtime checks before allocating memory so that we can abort execution if something is not quite right
- refactors runtime checks into `sphere::sane` method
- as a result of these changes we can now make the `sphere::grid` method pure