### PR TITLE
implements initial checkpointing [FORTRAN]

### DIFF
--- a/api/fortran/module/io/io.f
+++ b/api/fortran/module/io/io.f
@@ -148,6 +148,32 @@ c         IO status
         end function fopen_wr
 
 
+        function fopen_ow (filename, fd) result(status)
+c         Synopsis:
+c         Opens filename for writing, overwrites the file contents if existing.
+c         On success (failure) the file descriptor `fd' is set (unknown).
+c         Returns the status of this operation to the caller.
+          character(len=__FNAME_LENGTH__), intent(in) :: filename
+c         file descriptor
+          integer(kind = int64), intent(out) :: fd
+c         IO status
+          integer(kind = int64) :: status
+          integer(kind = int64) :: iostat
+
+          open(newunit = fd,
+     +         file = trim(filename),
+     +         form = 'formatted',
+     +         access = 'sequential',
+     +         status = 'unknown',
+     +         action = 'write',
+     +         iostat = iostat)
+
+          status = fstatus(iostat)
+
+          return
+        end function fopen_ow
+
+
         function fopen_rd (filename, fd) result(status)
 c         Synopsis:
 c         Opens filename for reading.
@@ -191,14 +217,16 @@ c         IO status
           if ( present(action) ) then
 
             if (action == 'w') then
-              status = fopen_wr(filename, fd)
+              status = fopen_wr(filename, fd) ! opens for writing
+            else if (action == 'o') then
+              status = fopen_ow(filename, fd) ! opens for overwriting
             else
-              status = fopen_rd(filename, fd)
+              status = fopen_rd(filename, fd) ! opens for reading
             end if
 
           else
 
-            status = fopen_wr(filename, fd)
+            status = fopen_wr(filename, fd)   ! defaults to writing
 
           end if
 
@@ -602,7 +630,7 @@ c         format for reading the step number (or state)
           character(*), parameter :: fmt = '(I64)'
 
 c         tries to open the state file for reading
-          status = fopen(filename = fname, fd = fd, action = 'w')
+          status = fopen(filename = fname, fd = fd, action = 'o')
           if (status == __FAILURE__) then
             print *, 'IO ERROR with file: ', trim(fname)
             return

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -10,6 +10,7 @@
         use :: io, only: io__flogger
         use :: io, only: io__floader
         use :: io, only: io__ffetch_state
+        use :: io, only: io__fdump_state
         use :: force, only: force__Brownian_force
         use :: system, only: system__PBC
         use :: dynamic, only: dynamic__shifter
@@ -251,10 +252,20 @@ c         Forwards the task to IO logger utility.
           class(sphere_t), intent(in) :: particles
 c         OBDS simulation step number (or identifier)
           integer(kind = int64), intent(in) :: step
+          real(kind = real64), pointer, contiguous :: tmp(:) => null()
 c         status of the IO operation
           integer(kind = int64) :: status
+          integer(kind = int64) :: istate
+
+          tmp => particles % tmp
+          istate = step
+          tmp(1) = real(istate, kind = real64)
 
           status = io__flogger(particles, step)
+
+          if (status == __SUCCESS__) then
+            status = io__fdump_state(particles)
+          end if
 
           return
         end function flogger


### PR DESCRIPTION
COMMENTS:
dumps the system state to the state file `run/bds/state/state.txt`

this feature has been tested in the HPC

this is the code that was missing in the previous merge ... 