### PR TITLE
dumps status to implement auto-scheduling [FORTRAN]

### DIFF
--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -13,6 +13,28 @@
         public :: NUM_LOG_STEPS
         public :: NUM_PARTICLES
         public :: LOG_NUM_PARTICLES
+        public :: PENDING
+        public :: DONE
+
+
+**                                                                    **
+*       OBDS Job status, either `unknown', `pending', or `done'        *
+        enum, bind(c)
+          enumerator :: UNKNOWN
+          enumerator :: PENDING
+          enumerator :: DONE
+        end enum
+*       NOTE:                                                          *
+*       The `unknown' status is not really dumped by the OBDS code, it *
+*       is dumped by the shell script that submits the code to the HPC *
+*       as a fail-safe mechanism to avert a job-scheduling hell, which *
+*       can happen if an unexpected error occurs (without fail-safe)   *
+*       The `pending' status signals the shell script to submit the    *
+*       job to the HPC because the simulation has not ended yet. The   *
+*       `done' status is dumped by the OBDS code when the simulation   *
+*       finishes, that happens the step counter is equal to NUM_STEPS. *
+**                                                                    **
+
 
 **                                                                    **
 *       system box limits and length                                   *

--- a/api/fortran/module/io/io.f
+++ b/api/fortran/module/io/io.f
@@ -611,18 +611,17 @@ c         closes the file
         end function fload_base
 
 
-        function fdump_state (state) result(status)
+        function fdump_state (istate) result(status)
 c         Synopsis:
 c         Dumps the last known system state to the state file, where the `state' is
 c         the last known simulation step number
 c         Returns the status of this operation to the caller.
-          real(kind = real64), intent(in) :: state
+          integer(kind = int64), intent(in) :: istate
 c         file descriptor
           integer(kind = int64) :: fd
 c         IO status
           integer(kind = int64) :: status
           integer(kind = int64) :: iostat
-          integer(kind = int64) :: istate
 c         name of the state file
           character(len = __FNAME_LENGTH__), parameter :: fname =
      +    'run/bds/state/state.txt'
@@ -636,7 +635,6 @@ c         tries to open the state file for reading
             return
           end if
 
-          istate = int(state, kind = int64)
 c         tries to write the state to the state file
           write(unit = fd, fmt = fmt, iostat = iostat) istate
 
@@ -721,25 +719,16 @@ c         against invalid inputs
         end function ffetch_state
 
 
-        function fdump_state_base (particles) result(status)
+        function fdump_state_base (istate) result(status)
 c         Synopsis:
 c         Dumps the OBDS state (holds the simulation step number) to the state file.
 c         Returns the status of this operation to the caller.
-c         NOTE:
-c         We can afford to read the `state' of integer kind from the temporary placeholder
-c         of real kind because integers have exact binary floating-point representations.
-          class(particle_t), intent(in), target :: particles
-c         temporary placeholder array
-          real(kind = real64), pointer, contiguous :: tmp(:) => null()
+c         system state (stands for the simulation step number)
+          integer(kind = int64), intent(in) :: istate
 c         IO status
           integer(kind = int64) :: status
-c         system state (stands for the simulation step number)
-          real(kind = real64) :: state
 
-          tmp => particles % tmp
-          state = tmp(1)
-
-          status = fdump_state(state)
+          status = fdump_state(istate)
 
           return
         end function fdump_state_base

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -252,19 +252,15 @@ c         Forwards the task to IO logger utility.
           class(sphere_t), intent(in) :: particles
 c         OBDS simulation step number (or identifier)
           integer(kind = int64), intent(in) :: step
-          real(kind = real64), pointer, contiguous :: tmp(:) => null()
 c         status of the IO operation
           integer(kind = int64) :: status
           integer(kind = int64) :: istate
 
-          tmp => particles % tmp
-          istate = step
-          tmp(1) = real(istate, kind = real64)
-
           status = io__flogger(particles, step)
 
           if (status == __SUCCESS__) then
-            status = io__fdump_state(particles)
+            istate = step
+            status = io__fdump_state(istate)
           end if
 
           return

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -7,10 +7,14 @@
         use :: config, only: LIMIT
         use :: config, only: LENGTH
         use :: config, only: NUM_SPHERES => NUM_PARTICLES
+        use :: config, only: NUM_STEPS
+        use :: config, only: PENDING
+        use :: config, only: DONE
         use :: io, only: io__flogger
         use :: io, only: io__floader
         use :: io, only: io__ffetch_state
         use :: io, only: io__fdump_state
+        use :: io, only: io__fdump_status
         use :: force, only: force__Brownian_force
         use :: system, only: system__PBC
         use :: dynamic, only: dynamic__shifter
@@ -257,10 +261,20 @@ c         status of the IO operation
           integer(kind = int64) :: istate
 
           status = io__flogger(particles, step)
+          if (status == __FAILURE__) then
+            return
+          end if
 
-          if (status == __SUCCESS__) then
-            istate = step
-            status = io__fdump_state(istate)
+          istate = step
+          status = io__fdump_state(istate)
+          if (status == __FAILURE__) then
+            return
+          end if
+
+          if (step == NUM_STEPS) then
+            status = io__fdump_status(DONE)
+          else
+            status = io__fdump_status(PENDING)
           end if
 
           return


### PR DESCRIPTION
The shell script that submits the job reads the status file dumped by the OBDS code, if the simulation is not done the script submits the job for scheduling to the HPCf. This is repeated until the simulation is done without the user to intervene. 

This is the simplest way of implementing this feature.