### PR TITLE
adds timer for stopping the OBDS App [FORTRAN]

### DIFF
--- a/api/fortran/bds/make-inc
+++ b/api/fortran/bds/make-inc
@@ -32,6 +32,8 @@ OBDS_F = OpenBDS.f
 # objects
 CONFIG_O   = ../module/config/config.o
 
+TIMER_O   = ../module/timer/timer.o
+
 RANDOM_O   = ../module/random/random.o
 
 PARTICLE_O = ../module/particle/particle.o\
@@ -45,7 +47,14 @@ FORCE_O    = ../module/force/force.o
 
 DYNAMIC_O  = ../module/dynamic/dynamic.o
 
-OBJS = $(CONFIG_O) $(RANDOM_O) $(PARTICLE_O) $(SYSTEM_O) $(IO_O) $(FORCE_O) $(DYNAMIC_O)
+OBJS = $(CONFIG_O)\
+       $(TIMER_O)\
+       $(RANDOM_O)\
+       $(PARTICLE_O)\
+       $(SYSTEM_O)\
+       $(IO_O)\
+       $(FORCE_O)\
+       $(DYNAMIC_O)
 
 OBDS_O = OpenBDS.o
 

--- a/api/fortran/module/Makefile
+++ b/api/fortran/module/Makefile
@@ -22,6 +22,9 @@ configs:
 PRNGs:
 	@$(MAKE) -C random
 
+timers: configs
+	@$(MAKE) -C timer
+
 particles: configs
 	@$(MAKE) -C particle
 
@@ -37,11 +40,12 @@ forces: particles PRNGs
 dynamics: forces
 	@$(MAKE) -C dynamic
 
-spheres: ios dynamics systems
+spheres: ios timers dynamics systems
 	@$(MAKE) -C sphere
 
 clean:
 	@$(MAKE) -C config clean
+	@$(MAKE) -C timer clean
 	@$(MAKE) -C random clean
 	@$(MAKE) -C particle clean
 	@$(MAKE) -C system clean

--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -1,5 +1,4 @@
       module config
-        use, intrinsic :: iso_fortran_env, only: int32
         use, intrinsic :: iso_fortran_env, only: int64
         use, intrinsic :: iso_fortran_env, only: real64
         implicit none
@@ -72,13 +71,13 @@
 
 **                                                                    **
 *       defines the walltime (alloted runtime for the application in   *
-*       the High Performance Computing facility HPCf in milliseconds)  *
-        integer(kind = int32), parameter :: WALLTIME_HRS = 164_int32
-        integer(kind = int32), parameter :: WALLTIME_SEC = 3600_int32 *
+*       the High Performance Computing facility HPCf in seconds)       *
+        integer(kind = int64), parameter :: WALLTIME_HRS = 164_int64
+        integer(kind = int64), parameter :: WALLTIME_SEC = 3600_int64 *
      +                                      WALLTIME_HRS
-        integer(kind = int32), parameter :: WALLTIME_MILLIS =
-     +                                      1000_int32 * WALLTIME_SEC
-        integer(kind = int32), parameter :: WALLTIME = WALLTIME_MILLIS
+        integer(kind = int64), parameter :: WALLTIME_MILLIS =
+     +                                      1000_int64 * WALLTIME_SEC
+        integer(kind = int64), parameter :: WALLTIME = WALLTIME_SEC
 *                                                                      *
 **                                                                    **
 

--- a/api/fortran/module/timer/Makefile
+++ b/api/fortran/module/timer/Makefile
@@ -1,8 +1,8 @@
 #!/usr/bin/make
 #
-# OpenBDS						October 22, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/fortran/bds/Makefile
+# source: api/fortran/module/timer/Makefile
 # author: @misael-diaz
 #
 # Synopsis:
@@ -16,13 +16,10 @@
 
 include make-inc
 
-all: $(OBDS_BIN)
+all: $(TIMER_O)
 
-$(OBDS_BIN): $(OBDS_O)
-	$(FC) $(FCOPT) $(OBJS) $(OBDS_O) -o $(OBDS_BIN)
-
-$(OBDS_O): $(MODULES) $(OBJS) $(OBDS_F)
-	$(FC) $(INC) $(IMODS) $(FCOPT) -c $(OBDS_F) -o $(OBDS_O)
+$(TIMER_O): $(MODULES) $(TIMER_F)
+	$(FC) $(FCOPT) -c $(TIMER_F) -o $(TIMER_O) $(FMOD) $(MODS)
 
 clean:
-	/bin/rm -f *.o *.mod *.bin
+	/bin/rm -f *.o

--- a/api/fortran/module/timer/make-inc
+++ b/api/fortran/module/timer/make-inc
@@ -1,8 +1,7 @@
-#!/usr/bin/make
 #
-# OpenBDS						October 22, 2023
+# OpenBDS						October 21, 2023
 #
-# source: api/fortran/bds/Makefile
+# source: api/fortran/module/timer/make-inc
 # author: @misael-diaz
 #
 # Synopsis:
@@ -14,15 +13,15 @@
 # (at your option) any later version.
 #
 
-include make-inc
+# modules
+CONFIG_MOD   = ../mods/config.mod
+MODULES = $(CONFIG_MOD)
 
-all: $(OBDS_BIN)
+# sources
+TIMER_F = timer.f
 
-$(OBDS_BIN): $(OBDS_O)
-	$(FC) $(FCOPT) $(OBJS) $(OBDS_O) -o $(OBDS_BIN)
+# objects
+TIMER_O = timer.o
 
-$(OBDS_O): $(MODULES) $(OBJS) $(OBDS_F)
-	$(FC) $(INC) $(IMODS) $(FCOPT) -c $(OBDS_F) -o $(OBDS_O)
-
-clean:
-	/bin/rm -f *.o *.mod *.bin
+# output directory the FORTRAN module files *.mod
+MODS = ../mods

--- a/api/fortran/module/timer/timer.f
+++ b/api/fortran/module/timer/timer.f
@@ -1,0 +1,159 @@
+      module timer
+        use, intrinsic :: iso_fortran_env, only: int64
+        use :: config, only: WALLTIME ! OBDS App WALLTIME [seconds]
+        implicit none
+        private
+
+        type, public :: timer_t
+          private
+          integer(kind = int64) :: resolution = 0_int64
+          integer(kind = int64) :: time_start = 0_int64
+          integer(kind = int64) :: time_end   = 0_int64
+          contains
+            private
+            procedure :: t_fgetetime => timer_fgetetime
+            procedure :: t_start_setter => timer_start_setter
+            procedure :: t_end_setter => timer_end_setter
+            procedure :: timer_falarm
+            procedure, public :: t_start => timer_start
+            procedure, public :: t_end => timer_end
+            procedure, public :: t_falarm => timer_falarm
+        end type
+
+        interface timer_t
+          module procedure constructor
+        end interface
+
+      contains
+
+        function ftime () result(t)
+          integer(kind = int64) :: t
+
+          call system_clock(count = t)
+
+        end function ftime
+
+
+        subroutine timer_start (this)
+          class(timer_t), intent(inout) :: this
+          integer(kind = int64) :: time_start
+
+          time_start = ftime()
+          call this % t_start_setter(time_start)
+
+          return
+        end subroutine timer_start
+
+
+        subroutine timer_end (this)
+          class(timer_t), intent(inout) :: this
+          integer(kind = int64) :: time_end
+
+          time_end = ftime()
+          call this % t_end_setter(time_end)
+
+          return
+        end subroutine timer_end
+
+
+        pure subroutine timer_start_setter (this, time_start)
+          class(timer_t), intent(inout) :: this
+          integer(kind = int64), intent(in) :: time_start
+
+          this % time_start = time_start
+
+          return
+        end subroutine timer_start_setter
+
+
+        pure subroutine timer_end_setter (this, time_end)
+          class(timer_t), intent(inout) :: this
+          integer(kind = int64), intent(in) :: time_end
+
+          this % time_end = time_end
+
+          return
+        end subroutine timer_end_setter
+
+
+        pure function timer_fgetetime (this) result(etime)
+          class(timer_t), intent(in) :: this
+          integer(kind = int64) :: etime
+          integer(kind = int64) :: time_start
+          integer(kind = int64) :: time_end
+          integer(kind = int64) :: time_elapsed
+
+          time_start = this % time_start
+          time_end = this % time_end
+          time_elapsed = (time_end - time_start)
+          etime = time_elapsed
+
+          return
+        end function timer_fgetetime
+
+
+        pure function timer_falarm (this) result(enabled)
+c         Synopsis:
+c         Sets the alarm if the walltime has been reached.
+          class(timer_t), intent(in) :: this
+          logical(kind = int64) :: enabled
+          integer(kind = int64) :: resolution
+          integer(kind = int64) :: time_elapsed
+          integer(kind = int64) :: wtime
+
+          time_elapsed = this % t_fgetetime()
+
+c         converts seconds to whatever time-unit (millis, us, ns) `system_clock()' uses
+          resolution = this % resolution
+          wtime = resolution * WALLTIME
+          if (time_elapsed >= wtime) then
+            enabled = .true.
+          else
+            enabled = .false.
+          end if
+
+          return
+        end function timer_falarm
+
+
+        function constructor () result(timer)
+          type(timer_t) :: timer
+          integer(kind = int64) :: system_clock__resolution
+
+          call system_clock(count_rate = system_clock__resolution)
+          timer % resolution = system_clock__resolution
+          timer % time_start = 0_int64
+          timer % time_end   = 0_int64
+
+          return
+        end function constructor
+
+      end module timer
+
+*   OpenBDS                                             November 05, 2023
+*
+*   source: api/fortran/module/timer/timer.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Implements a timer for stopping the OBDS app after it has reached the walltime.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.


### PR DESCRIPTION
COMMENTS:
We need a timer that stops the OBDS App once the walltime in the HPC cluster is reached.

The implementation accounts for the system-clock portability issues. For example, if the code is compiled with GNU FORTRAN Compiler the system clock might have a nanosecond resolution whereas if it is compiled with the Intel FORTRAN Compiler it might have a micro second resolution. To work around this we simply define the walltime in seconds and use the system-clock count-rate to perform the conversion from seconds to `counts`.