### PR TITLE
adds Shifted Lennard-Jones SLJ force [FORTRAN]

### DIFF
--- a/api/fortran/bds/make-inc
+++ b/api/fortran/bds/make-inc
@@ -34,6 +34,8 @@ CONFIG_O   = ../module/config/config.o
 
 TIMER_O   = ../module/timer/timer.o
 
+VECTOR_O   = ../module/vector/vector.o
+
 RANDOM_O   = ../module/random/random.o
 
 PARTICLE_O = ../module/particle/particle.o\
@@ -49,6 +51,7 @@ DYNAMIC_O  = ../module/dynamic/dynamic.o
 
 OBJS = $(CONFIG_O)\
        $(TIMER_O)\
+       $(VECTOR_O)\
        $(RANDOM_O)\
        $(PARTICLE_O)\
        $(SYSTEM_O)\

--- a/api/fortran/module/Makefile
+++ b/api/fortran/module/Makefile
@@ -25,6 +25,9 @@ PRNGs:
 timers: configs
 	@$(MAKE) -C timer
 
+vectors: configs
+	@$(MAKE) -C vector
+
 particles: configs
 	@$(MAKE) -C particle
 
@@ -40,12 +43,13 @@ forces: particles PRNGs
 dynamics: forces
 	@$(MAKE) -C dynamic
 
-spheres: ios timers dynamics systems
+spheres: ios timers vectors dynamics systems
 	@$(MAKE) -C sphere
 
 clean:
 	@$(MAKE) -C config clean
 	@$(MAKE) -C timer clean
+	@$(MAKE) -C vector clean
 	@$(MAKE) -C random clean
 	@$(MAKE) -C particle clean
 	@$(MAKE) -C system clean

--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -4,6 +4,7 @@
         implicit none
         private
         save
+        public :: CLAMP
         public :: LIMIT
         public :: LENGTH
         public :: TIME_STEP
@@ -12,6 +13,11 @@
         public :: NUM_LOG_STEPS
         public :: NUM_PARTICLES
         public :: LOG_NUM_PARTICLES
+        public :: SPH_RADIUS
+        public :: SPH_DIAMETER
+        public :: SPH_CONTACT
+        public :: SPH_INTERACT_RANGE
+        public :: INTERACT_ENABLE
         public :: PENDING
         public :: DONE
 
@@ -60,6 +66,9 @@
 *       after this number of steps the OBDS code logs data to a file   *
         integer(kind = int64), parameter :: NUM_LOG_STEPS =
      +  int(TIME_STEP_LOG / TIME_STEP, kind = int64)
+*       clamp value, no force component shall exceed this value
+        real(kind = real64), parameter :: CLAMP =
+     +  0.0625_real64 / TIME_STEP
 *       NOTE:
 *       The OBDS code logs the particle fields (or properties) to a    *
 *       plain text file after this (simulation) time interval has      *
@@ -101,12 +110,19 @@
 
 
 **                                                                    **
-*       enables computation of particle-particle interactions
-        logical(kind = int64), parameter :: INTERACT_ENABLE = .false.
+*       defines the sphere radius, diameter, and contact distance      *
+        real(kind = real64), parameter :: SPH_RADIUS = 1.0_real64
+        real(kind = real64), parameter :: SPH_DIAMETER =
+     +                                    2.0_real64 * SPH_RADIUS
+        real(kind = real64), parameter :: SPH_CONTACT = SPH_DIAMETER
+*       defines the interaction range for spheres                      *
+        real(kind = real64), parameter :: SPH_INTERACT_RANGE =
+     +                                    1.5_real64 * SPH_CONTACT
+*       enables computation of particle-particle interactions          *
+        logical(kind = int64), parameter :: INTERACT_ENABLE = .true.
 *       NOTE:
-*       Disabled temporarily since we have to yet implement this       *
-*       feature. Other reasons for disabling it are code profiling and *
-*       validating the statistics of the normally-distributed          *
+*       Reasons for disabling particle interactions are code profiling *
+*       and validating the statistics of the normally-distributed      *
 *       Pseudo Random Number Generator PRNG.                           *
 **                                                                    **
 

--- a/api/fortran/module/force/force.f
+++ b/api/fortran/module/force/force.f
@@ -1,16 +1,624 @@
+c defines MACROS to make the code more readable and easier to maintain:
+
+c arguments of procedure virtpos():
+#define VP_ARG \
+      x,\
+      y,\
+      z,\
+      of_x,\
+      of_y,\
+      of_z,\
+      rj_x,\
+      rj_y,\
+      rj_z
+
+c arguments of procedure relpos():
+#define RP_ARG \
+      ri_x,\
+      ri_y,\
+      ri_z,\
+      rj_x,\
+      rj_y,\
+      rj_z,\
+      rij_x,\
+      rij_y,\
+      rij_z
+
+c arguments of procedure dist():
+#define D_ARG \
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij2,\
+      rij
+
+c arguments of procedure callback_SLJ_handler_dest():
+#define CB_SLJ_HD_ARG \
+      particles,\
+      F_x,\
+      F_y,\
+      F_z,\
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij,\
+      Fij,\
+      rij7,\
+      rij8_inv,\
+      rc7_inv
+
+c defines alias for convenience
+#define CBSLJHD_ARG CB_SLJ_HD_ARG
+
+c arguments of procedure SLJ_force_dist_ratio_calc():
+#define SLJ_FDRC_ARG \
+      rij,\
+      Fij,\
+      rij7,\
+      rij8_inv,\
+      rc7_inv
+
+c defines alias for convenience
+#define SLJFDRC_ARG SLJ_FDRC_ARG
+
+c arguments of procedure SLJ_force_nointeract_zero():
+#define SLJ_FNIZ_ARG \
+      i,\
+      rij,\
+      Fij
+
+c defines alias for convenience
+#define SLJFNIZ_ARG SLJ_FNIZ_ARG
+
+c arguments of procedure SLJ_force_resultant():
+#define SLJ_FR_ARG \
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      Fij,\
+      Fi_x,\
+      Fi_y,\
+      Fi_z
+
+c defines alias for convenience
+#define SLJFR_ARG SLJ_FR_ARG
+
+c arguments of procedure SLJ_force():
+#define SLJ_F_ARG \
+      i,\
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij,\
+      Fi_x,\
+      Fi_y,\
+      Fi_z,\
+      Fij,\
+      rij7,\
+      rij8_inv,\
+      rc7_inv
+
+c defines alias for convenience
+#define SLJF_ARG SLJ_F_ARG
+
+c arguments of procedure brute_force_dest():
+#define BFDEST_ARG \
+      particles,\
+      x,\
+      y,\
+      z,\
+      F_x,\
+      F_y,\
+      F_z,\
+      ri_x,\
+      ri_y,\
+      ri_z,\
+      of_x,\
+      of_y,\
+      of_z,\
+      rj_x,\
+      rj_y,\
+      rj_z,\
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij,\
+      rij2
+
+c arguments of procedure brute_force_virt():
+#define BFVIRT_ARG \
+      offset_x,\
+      offset_y,\
+      offset_z,\
+      x,\
+      y,\
+      z,\
+      of_x,\
+      of_y,\
+      of_z,\
+      rj_x,\
+      rj_y,\
+      rj_z
+
+c arguments of procedure brute_force_vec():
+#define BFVEC_ARG \
+      i,\
+      x,\
+      y,\
+      z,\
+      ri_x,\
+      ri_y,\
+      ri_z
+
+c arguments of procedure brute_force_relpos():
+#define BFRP_ARG RP_ARG
+
+c arguments of procedure brute_force_dist():
+#define BFDIST_ARG D_ARG
+
+c arguments of procedure brute_force_iter():
+#define BFI_ARG \
+      particles,\
+      i,\
+      x,\
+      y,\
+      z,\
+      rj_x,\
+      rj_y,\
+      rj_z,\
+      ri_x,\
+      ri_y,\
+      ri_z,\
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij,\
+      rij2
+
+c arguments of procedure brute_force_loop():
+#define BFL_ARG \
+      particles,\
+      x,\
+      y,\
+      z,\
+      rj_x,\
+      rj_y,\
+      rj_z,\
+      ri_x,\
+      ri_y,\
+      ri_z,\
+      rij_x,\
+      rij_y,\
+      rij_z,\
+      rij,\
+      rij2
+
+c arguments of procedure brute_force():
+#define BF_ARG \
+      particles,\
+      offset_x,\
+      offset_y,\
+      offset_z
+
+c arguments of procedure brute_force_offset():
+#define BFO_ARG BF_ARG
+
+c arguments of procedure brute_force_driver_dest():
+#define BFDD_ARG \
+      particles,\
+      F_x,\
+      F_y,\
+      F_z
+
       module force
+        use, intrinsic :: iso_fortran_env, only: int64
         use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
+        use :: config, only: CLAMP
+        use :: config, only: SPH_CONTACT
+        use :: config, only: SPH_INTERACT_RANGE
+        use :: config, only: L => LENGTH
         use :: config, only: N => NUM_PARTICLES
+        use :: config, only: rc => SPH_INTERACT_RANGE ! cutoff-radius rc
+        use :: vector, only: vector__vec
+        use :: vector, only: vector__add
+        use :: vector, only: vector__diff
+        use :: vector, only: vector__norm
         use :: particle, only: particle_t
         use :: random, only: fnrand
         implicit none
         private
         public :: force__Brownian_force
+        public :: force__callback_SLJ_handler
+        public :: force__brute_force
 
         interface force__Brownian_force
           module procedure Brownian_force_base
         end interface
 
+        interface force__callback_SLJ_handler
+          module procedure callback_SLJ_handler
+        end interface
+
+        interface force__brute_force
+          module procedure brute_force_base
+        end interface
+
+        interface
+c         obtains the virtual position-vector of the jth-particles
+          pure module subroutine virtpos (VP_ARG)
+c           position vector components
+            real(r8), intent(in) :: x(N)
+            real(r8), intent(in) :: y(N)
+            real(r8), intent(in) :: z(N)
+c           vectorized offset-vector components
+            real(r8), intent(in) :: of_x(N)
+            real(r8), intent(in) :: of_y(N)
+            real(r8), intent(in) :: of_z(N)
+c           virtual position-vector components of the jth-particles
+            real(r8), intent(out) :: rj_x(N)
+            real(r8), intent(out) :: rj_y(N)
+            real(r8), intent(out) :: rj_z(N)
+          end subroutine virtpos
+c         NOTE:
+c         We use `virtual' to emphasize that the jth-particles may be virtual (not actual)
+c         particles as a consequence of the periodic boundaries of the system.
+        end interface
+
+        interface
+c         computes the relative-position vector `rij' components
+          pure module subroutine relpos (RP_ARG)
+c           vectorized position-vector components of the ith-particle
+            real(r8), intent(in) :: ri_x(N)
+            real(r8), intent(in) :: ri_y(N)
+            real(r8), intent(in) :: ri_z(N)
+c           position-vector components of the jth-particles
+            real(r8), intent(in) :: rj_x(N)
+            real(r8), intent(in) :: rj_y(N)
+            real(r8), intent(in) :: rj_z(N)
+c           relative-position vector components
+            real(r8), intent(out) :: rij_x(N)
+            real(r8), intent(out) :: rij_y(N)
+            real(r8), intent(out) :: rij_z(N)
+          end subroutine relpos
+        end interface
+
+        interface
+c         computes the (squared) magnitude of the relative-position vector `rij'
+          pure module subroutine dist (D_ARG)
+c           relative-position vector components
+            real(r8), intent(in) :: rij_x(N)
+            real(r8), intent(in) :: rij_y(N)
+            real(r8), intent(in) :: rij_z(N)
+c           squared magnitude of the relative-position vector `rij'
+            real(r8), intent(out) :: rij2(N)
+c           magnitude of the relative-position vector `rij'
+            real(r8), intent(out) :: rij(N)
+          end subroutine dist
+        end interface
+
+        interface
+c         computes the ratio of the SLJ-force magnitude `Fij' to the distance `rij'
+          pure module subroutine SLJ_force_dist_ratio_calc (SLJFDRC_ARG)
+            real(r8), intent(in) :: rij(N)
+            real(r8), intent(out) :: Fij(N)
+c           placeholders for intermediate computations
+            real(r8), intent(out) :: rij7(N)
+            real(r8), intent(out) :: rij8_inv(N)
+            real(r8), intent(out) :: rc7_inv(N)
+          end subroutine SLJ_force_dist_ratio_calc
+        end interface
+
+        interface
+c         zeros the force `Fij' on non-interacting pairs of particles
+          elemental module subroutine force_nointeract_zero (rij, Fij)
+            real(r8), intent(in) :: rij
+            real(r8), intent(inout) :: Fij
+          end subroutine
+        end interface
+
+        interface
+c         zeros the SLJ-force (to distance ratio) of non-interacting pairs of particles
+          pure module subroutine SLJ_force_nointeract_zero (SLJFNIZ_ARG)
+            integer(i8), intent(in) :: i
+            real(r8), intent(in) :: rij(N)
+            real(r8), intent(inout) :: Fij(N)
+          end subroutine SLJ_force_nointeract_zero
+        end interface
+
+        interface
+c         updates the resultant SLJ-force on the ith-particle
+          pure module subroutine SLJ_force_resultant (SLJFR_ARG)
+            real(r8), intent(in) :: rij_x(N)
+            real(r8), intent(in) :: rij_y(N)
+            real(r8), intent(in) :: rij_z(N)
+            real(r8), intent(in) :: Fij(N)
+            real(r8), intent(inout) :: Fi_x
+            real(r8), intent(inout) :: Fi_y
+            real(r8), intent(inout) :: Fi_z
+          end subroutine SLJ_force_resultant
+        end interface
+
+        interface
+c         drives the computation of the SLJ-force on the ith-particle
+          pure module subroutine SLJ_force (SLJF_ARG)
+c           ith-particle identifier ID
+            integer(i8), intent(in) :: i
+c           relative-position vector components
+            real(r8), intent(in) :: rij_x(N)
+            real(r8), intent(in) :: rij_y(N)
+            real(r8), intent(in) :: rij_z(N)
+            real(r8), intent(in) :: rij(N)
+c           force vector components of the ith-particle
+            real(r8), intent(inout) :: Fi_x
+            real(r8), intent(inout) :: Fi_y
+            real(r8), intent(inout) :: Fi_z
+c           placeholders for intermediate computations
+            real(r8), intent(out) :: Fij(N)
+            real(r8), intent(out) :: rij7(N)
+            real(r8), intent(out) :: rij8_inv(N)
+            real(r8), intent(out) :: rc7_inv(N)
+          end subroutine SLJ_force
+        end interface
+
+        interface
+c         clamps a component of the force vector
+          elemental module subroutine clamper (F_x)
+            real(r8), intent(inout) :: F_x
+          end subroutine clamper
+        end interface
+
+        interface
+c         clamps the force vector so that its maximum does not exceed `CLAMP'
+          pure module subroutine force_clamp (F_x, F_y, F_z)
+            real(r8), intent(inout) :: F_x(N)
+            real(r8), intent(inout) :: F_y(N)
+            real(r8), intent(inout) :: F_z(N)
+          end subroutine force_clamp
+        end interface
+
+        interface
+c         destructures the needed fields (or properties) of the `particles' object
+          pure module subroutine callback_SLJ_handler_dest (CBSLJHD_ARG)
+            class(particle_t), intent(inout), target :: particles
+c           force vector components
+            real(r8), pointer, contiguous, intent(out) :: F_x(:)
+            real(r8), pointer, contiguous, intent(out) :: F_y(:)
+            real(r8), pointer, contiguous, intent(out) :: F_z(:)
+c           relative-position vector components
+            real(r8), pointer, contiguous, intent(out) :: rij_x(:)
+            real(r8), pointer, contiguous, intent(out) :: rij_y(:)
+            real(r8), pointer, contiguous, intent(out) :: rij_z(:)
+c           relative-position vector magnitudes
+            real(r8), pointer, contiguous, intent(out) :: rij(:)
+c           temporary placeholders
+            real(r8), pointer, contiguous, intent(out) :: Fij(:)
+            real(r8), pointer, contiguous, intent(out) :: rij7(:)
+            real(r8), pointer, contiguous, intent(out) :: rij8_inv(:)
+            real(r8), pointer, contiguous, intent(out) :: rc7_inv(:)
+          end subroutine callback_SLJ_handler_dest
+        end interface
+
+        interface
+c         handles the callback to compute the SLJ force on the ith-particle
+          pure module subroutine callback_SLJ_handler (particles, i)
+            class(particle_t), intent(inout) :: particles
+            integer(i8), intent(in) :: i ! ith-particle identifier ID
+          end subroutine
+        end interface
+
+        interface
+c         destructures the needed fields (or properties) of the `particles' object
+          pure module subroutine brute_force_dest (BFDEST_ARG)
+            class(particle_t), intent(inout), target :: particles
+c           position vector components
+            real(r8), pointer, contiguous, intent(out) :: x(:)
+            real(r8), pointer, contiguous, intent(out) :: y(:)
+            real(r8), pointer, contiguous, intent(out) :: z(:)
+c           force vector components
+            real(r8), pointer, contiguous, intent(out) :: F_x(:)
+            real(r8), pointer, contiguous, intent(out) :: F_y(:)
+            real(r8), pointer, contiguous, intent(out) :: F_z(:)
+c           vectorized position-vector components of the ith-particle
+            real(r8), pointer, contiguous, intent(out) :: ri_x(:)
+            real(r8), pointer, contiguous, intent(out) :: ri_y(:)
+            real(r8), pointer, contiguous, intent(out) :: ri_z(:)
+c           vectorized offset-vector components
+            real(r8), pointer, contiguous, intent(out) :: of_x(:)
+            real(r8), pointer, contiguous, intent(out) :: of_y(:)
+            real(r8), pointer, contiguous, intent(out) :: of_z(:)
+c           virtual position-vector components of the jth-particles
+            real(r8), pointer, contiguous, intent(out) :: rj_x(:)
+            real(r8), pointer, contiguous, intent(out) :: rj_y(:)
+            real(r8), pointer, contiguous, intent(out) :: rj_z(:)
+c           relative-position vector components
+            real(r8), pointer, contiguous, intent(out) :: rij_x(:)
+            real(r8), pointer, contiguous, intent(out) :: rij_y(:)
+            real(r8), pointer, contiguous, intent(out) :: rij_z(:)
+c           magnitude of the relative-position vector `rij'
+            real(r8), pointer, contiguous, intent(out) :: rij(:)
+c           squared magnitude of the relative-position vector `rij'
+            real(r8), pointer, contiguous, intent(out) :: rij2(:)
+          end subroutine brute_force_dest
+        end interface
+
+        interface
+c         destructures the needed fields (or properties) of the `particles' object
+          pure module subroutine brute_force_driver_dest (BFDD_ARG)
+            class(particle_t), intent(inout), target :: particles
+c           force vector components
+            real(r8), pointer, contiguous, intent(out) :: F_x(:)
+            real(r8), pointer, contiguous, intent(out) :: F_y(:)
+            real(r8), pointer, contiguous, intent(out) :: F_z(:)
+          end subroutine
+        end interface
+
+        interface
+c         computes the position vectors of the virtual jth-particles that interact with
+c         the ith-particle
+          pure module subroutine brute_force_virt (BFVIRT_ARG)
+c           offset along the axes
+            real(r8), intent(in) :: offset_x
+            real(r8), intent(in) :: offset_y
+            real(r8), intent(in) :: offset_z
+c           position vector components
+            real(r8), intent(in) :: x(N)
+            real(r8), intent(in) :: y(N)
+            real(r8), intent(in) :: z(N)
+c           vectorized offset-vector components
+            real(r8), intent(out) :: of_x(N)
+            real(r8), intent(out) :: of_y(N)
+            real(r8), intent(out) :: of_z(N)
+c           virtual position-vector components
+            real(r8), intent(out) :: rj_x(N)
+            real(r8), intent(out) :: rj_y(N)
+            real(r8), intent(out) :: rj_z(N)
+          end subroutine brute_force_virt
+        end interface
+
+        interface
+c         vectorizes the position vector components of the ith-particle
+          pure module subroutine brute_force_vec (BFVEC_ARG)
+c           ith-particle identifier ID
+            integer(i8), intent(in) :: i
+c           position vector components
+            real(r8), intent(in) :: x(N)
+            real(r8), intent(in) :: y(N)
+            real(r8), intent(in) :: z(N)
+c           vectorized position vector components of the ith-particle
+            real(r8), intent(out) :: ri_x(N)
+            real(r8), intent(out) :: ri_y(N)
+            real(r8), intent(out) :: ri_z(N)
+          end subroutine brute_force_vec
+        end interface
+
+        interface
+c         obtains the relative-position vector of the i-j particle pairs
+          pure module subroutine brute_force_relpos (BFRP_ARG)
+c           vectorized position-vector components of the ith-particle
+            real(r8), intent(in) :: ri_x(N)
+            real(r8), intent(in) :: ri_y(N)
+            real(r8), intent(in) :: ri_z(N)
+c           position-vector components of the jth-particles
+            real(r8), intent(in) :: rj_x(N)
+            real(r8), intent(in) :: rj_y(N)
+            real(r8), intent(in) :: rj_z(N)
+c           relative-position vector components
+            real(r8), intent(out) :: rij_x(N)
+            real(r8), intent(out) :: rij_y(N)
+            real(r8), intent(out) :: rij_z(N)
+          end subroutine brute_force_relpos
+        end interface
+
+        interface
+c         obtains the (squared) relative-distances between the i-j particle pairs
+          pure module subroutine brute_force_dist (BFDIST_ARG)
+c           relative-position vector components
+            real(r8), intent(in) :: rij_x(N)
+            real(r8), intent(in) :: rij_y(N)
+            real(r8), intent(in) :: rij_z(N)
+c           squared magnitude of the relative-position vector `rij'
+            real(r8), intent(out) :: rij2(N)
+c           magnitude of the relative-position vector `rij'
+            real(r8), intent(out) :: rij(N)
+          end subroutine brute_force_dist
+        end interface
+
+        interface
+c         updates the resultant force on the ith-particle
+          pure module subroutine brute_force_iter (BFI_ARG)
+            class(particle_t), intent(inout) :: particles
+c           ith-particle identifier ID
+            integer(i8), intent(in) :: i
+c           position vector components
+            real(r8), intent(in) :: x(N)
+            real(r8), intent(in) :: y(N)
+            real(r8), intent(in) :: z(N)
+c           position vector components of the jth-particles
+            real(r8), intent(in) :: rj_x(N)
+            real(r8), intent(in) :: rj_y(N)
+            real(r8), intent(in) :: rj_z(N)
+c           (vectorized) position vector components of the ith-particle
+            real(r8), intent(out) :: ri_x(N)
+            real(r8), intent(out) :: ri_y(N)
+            real(r8), intent(out) :: ri_z(N)
+c           relative-position vector components
+            real(r8), intent(out) :: rij_x(N)
+            real(r8), intent(out) :: rij_y(N)
+            real(r8), intent(out) :: rij_z(N)
+            real(r8), intent(out) :: rij2(N)
+            real(r8), intent(out) :: rij(N)
+          end subroutine brute_force_iter
+        end interface
+
+        interface
+c         updates the force on the ith-particles exerted by the jth virtual particles
+          pure module subroutine brute_force_loop (BFL_ARG)
+            class(particle_t), intent(inout) :: particles
+c           position vector components
+            real(r8), intent(in) :: x(N)
+            real(r8), intent(in) :: y(N)
+            real(r8), intent(in) :: z(N)
+c           position-vector components of the jth-particles
+            real(r8), intent(in) :: rj_x(N)
+            real(r8), intent(in) :: rj_y(N)
+            real(r8), intent(in) :: rj_z(N)
+c           vectorized position-vector components of the ith-particle
+            real(r8), intent(out) :: ri_x(N)
+            real(r8), intent(out) :: ri_y(N)
+            real(r8), intent(out) :: ri_z(N)
+c           relative-position vector components
+            real(r8), intent(out) :: rij_x(N)
+            real(r8), intent(out) :: rij_y(N)
+            real(r8), intent(out) :: rij_z(N)
+            real(r8), intent(out) :: rij(N)
+            real(r8), intent(out) :: rij2(N)
+          end subroutine brute_force_loop
+        end interface
+
+        interface
+c         computes the forces exerted by the virtual particles on the actual particles
+          pure module subroutine brute_force (BF_ARG)
+            class(particle_t), intent(inout) :: particles
+            real(r8), intent(in) :: offset_x
+            real(r8), intent(in) :: offset_y
+            real(r8), intent(in) :: offset_z
+          end subroutine brute_force
+c         NOTE: intent(inout) variables may be (indirectly) modified by the callback
+        end interface
+
+        interface
+c         forwards the task to the brute_force() procedure
+          pure module subroutine brute_force_offset (BFO_ARG)
+            class(particle_t), intent(inout) :: particles
+            real(r8), intent(in) :: offset_x
+            real(r8), intent(in) :: offset_y
+            real(r8), intent(in) :: offset_z
+          end subroutine brute_force_offset
+        end interface
+
+        interface
+c         constructs the particle images along some axis (or direction) `ax'
+          pure module subroutine brute_force_img (particles, ax)
+            class(particle_t), intent(inout) :: particles
+            character(len=1), intent(in) :: ax
+          end subroutine
+        end interface
+
+        interface
+c         drives the computation of the interparticle forces
+          pure module subroutine brute_force_driver (particles)
+            class(particle_t), intent(inout) :: particles
+          end subroutine
+        end interface
+
+        interface
+c         base code, forwards its task to the driver
+          pure module subroutine brute_force_base (particles)
+            class(particle_t), intent(inout) :: particles
+          end subroutine
+        end interface
       contains
 
         impure elemental subroutine Brownian_force_component (F_x)
@@ -58,6 +666,440 @@ c         Updates the force vectors with the Brownian forces.
         end subroutine Brownian_force_base
 
       end module force
+
+c     NOTE:
+c     if the code gets much larger we can relocate the submodule elsewhere to reduce
+c     the compilation time if that becomes a concern
+      submodule (force) brute_force_methods
+        implicit none
+      contains
+
+        module procedure virtpos
+
+          call vector__add(VP_ARG)
+
+          return
+        end procedure virtpos
+
+
+        module procedure relpos
+
+          call vector__diff(RP_ARG)
+
+          return
+        end procedure relpos
+
+
+        module procedure dist
+
+          call vector__norm(D_ARG)
+
+          return
+        end procedure dist
+
+
+        module procedure SLJ_force_dist_ratio_calc
+          real(r8), parameter :: C6 = (SPH_CONTACT**6)
+          real(r8), parameter :: SLJ_EPSILON = 1.0_r8
+          real(r8), parameter :: SLJ_EPS = SLJ_EPSILON
+          real(r8), parameter :: kappa = (4.0_r8 * SLJ_EPS * C6)
+          real(r8), parameter :: k = (6.0_r8 * kappa)
+
+          rij7 = rij**7
+          rc7_inv = rc**(-7)
+          rij8_inv = rij**(-8)
+
+c         we break down the computation of the following equation in the next lines:
+c               Fij = k * ( rij8_inv - (rc7_inv * rij7) * rij8_inv )
+c         note that the compiler can fuse the implicit loops if profitable (or optimal)
+
+          Fij = rc7_inv * rij7
+          rij7 = Fij * rij8_inv
+          Fij = rij8_inv - rij7
+          rc7_inv = k
+          rij7 = rc7_inv * Fij
+          Fij = rij7
+
+          return
+        end procedure SLJ_force_dist_ratio_calc
+
+
+        module procedure force_nointeract_zero
+
+          if (rij < SPH_INTERACT_RANGE) then
+            Fij = 1.0_r8 * Fij
+          else
+            Fij = 0.0_r8
+          end if
+
+          return
+        end procedure force_nointeract_zero
+
+
+        module procedure SLJ_force_nointeract_zero
+
+          Fij(i) = 0.0_r8
+
+          call force_nointeract_zero(rij, Fij)
+
+          return
+        end procedure SLJ_force_nointeract_zero
+
+
+        module procedure SLJ_force_resultant
+
+          Fi_x = Fi_x + sum(Fij * rij_x)
+          Fi_y = Fi_y + sum(Fij * rij_y)
+          Fi_z = Fi_z + sum(Fij * rij_z)
+
+          return
+        end procedure SLJ_force_resultant
+
+
+        module procedure SLJ_force
+
+          call SLJ_force_dist_ratio_calc(SLJ_FDRC_ARG)
+          call SLJ_force_nointeract_zero(SLJ_FNIZ_ARG)
+          call SLJ_force_resultant(SLJ_FR_ARG)
+
+          return
+        end procedure SLJ_force
+
+
+        module procedure clamper
+
+          if (F_x > CLAMP) then
+            F_x = +CLAMP
+          elseif (F_x < -CLAMP) then
+            F_x = -CLAMP
+          else
+            F_x = 1.0_r8 * F_x
+          end if
+
+          return
+        end procedure clamper
+
+
+        module procedure force_clamp
+
+          call clamper(F_x)
+          call clamper(F_y)
+          call clamper(F_z)
+
+          return
+        end procedure force_clamp
+
+
+        module procedure callback_SLJ_handler_dest
+c         size `sz' of the preceding (contiguous) memory block
+          integer(i8) :: sz
+
+          F_x => particles % F_x
+          F_y => particles % F_y
+          F_z => particles % F_z
+
+          Fij => particles % T_x
+          rij7 => particles % T_y
+          rij8_inv => particles % T_z
+
+          sz = 6_i8 * N
+          rij_x => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij_y => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij_z => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rc7_inv => particles % tmp(1 + sz:N + sz)
+
+          return
+        end procedure callback_SLJ_handler_dest
+
+
+        module procedure brute_force_dest
+c         size `sz' of the preceding (contiguous) memory block
+          integer(i8) :: sz
+
+          x => particles % x
+          y => particles % y
+          z => particles % z
+
+          F_x => particles % F_x
+          F_y => particles % F_y
+          F_z => particles % F_z
+
+          ri_x => particles % T_x
+          ri_y => particles % T_y
+          ri_z => particles % T_z
+
+          sz = 0_i8
+          of_x => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          of_y => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          of_z => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rj_x => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rj_y => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rj_z => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij_x => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij_y => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij_z => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij => particles % tmp(1 + sz:N + sz)
+
+          sz = sz + N
+          rij2 => particles % tmp(1 + sz:N + sz)
+
+          return
+        end procedure brute_force_dest
+
+
+        module procedure brute_force_driver_dest
+
+          F_x => particles % F_x
+          F_y => particles % F_y
+          F_z => particles % F_z
+
+          return
+        end procedure brute_force_driver_dest
+
+
+        module procedure callback_SLJ_handler
+c         (read-write) force vector components of the ith-particle
+          real(r8), pointer :: Fi_x
+          real(r8), pointer :: Fi_y
+          real(r8), pointer :: Fi_z
+c         (read-write) force vector components
+          real(r8), pointer, contiguous :: F_x(:)
+          real(r8), pointer, contiguous :: F_y(:)
+          real(r8), pointer, contiguous :: F_z(:)
+c         (read-only) relative position vector components
+          real(r8), pointer, contiguous :: rij_x(:)
+          real(r8), pointer, contiguous :: rij_y(:)
+          real(r8), pointer, contiguous :: rij_z(:)
+          real(r8), pointer, contiguous :: rij(:)
+c         (write-read) temporary placeholders
+          real(r8), pointer, contiguous :: Fij(:)
+          real(r8), pointer, contiguous :: rij7(:)
+          real(r8), pointer, contiguous :: rij8_inv(:)
+          real(r8), pointer, contiguous :: rc7_inv(:)
+
+          call callback_SLJ_handler_dest(CB_SLJ_HD_ARG)
+
+          Fi_x => F_x(i)
+          Fi_y => F_y(i)
+          Fi_z => F_z(i)
+
+          call SLJ_force(SLJF_ARG)
+
+          return
+        end procedure callback_SLJ_handler
+
+
+        module procedure brute_force_virt
+
+          call vector__vec(offset_x,
+     +                     offset_y,
+     +                     offset_z,
+     +                     of_x,
+     +                     of_y,
+     +                     of_z)
+
+          call virtpos(VP_ARG)
+
+          return
+        end procedure brute_force_virt
+
+
+        module procedure brute_force_vec
+          real(r8) :: x_i
+          real(r8) :: y_i
+          real(r8) :: z_i
+
+          x_i = x(i)
+          y_i = y(i)
+          z_i = z(i)
+
+          call vector__vec(x_i, y_i, z_i, ri_x, ri_y, ri_z)
+
+        end procedure brute_force_vec
+
+
+        module procedure brute_force_relpos
+
+          call relpos(RP_ARG)
+
+          return
+        end procedure brute_force_relpos
+
+
+        module procedure brute_force_dist
+
+          call dist(D_ARG)
+
+          return
+        end procedure brute_force_dist
+
+
+        module procedure brute_force_iter
+
+          call brute_force_vec(BFVEC_ARG)
+          call brute_force_relpos(BFRP_ARG)
+          call brute_force_dist(BFDIST_ARG)
+          call particles % callback(i)
+
+          return
+        end procedure brute_force_iter
+
+
+        module procedure brute_force_loop
+c         ith-particle identifier ID
+          integer(i8) :: i
+
+          do i = 1_i8, N
+
+            call brute_force_iter(BFI_ARG)
+
+          end do
+
+          return
+        end procedure brute_force_loop
+
+
+        module procedure brute_force
+c         (read-only) position vector components
+          real(r8), pointer, contiguous :: x(:)
+          real(r8), pointer, contiguous :: y(:)
+          real(r8), pointer, contiguous :: z(:)
+c         (read-write) force vector components
+          real(r8), pointer, contiguous :: F_x(:)
+          real(r8), pointer, contiguous :: F_y(:)
+          real(r8), pointer, contiguous :: F_z(:)
+c         (write-read) vectorized position-vector component of the ith particle
+          real(r8), pointer, contiguous :: ri_x(:)
+          real(r8), pointer, contiguous :: ri_y(:)
+          real(r8), pointer, contiguous :: ri_z(:)
+c         (write-read) offset-vector components
+          real(r8), pointer, contiguous :: of_x(:)
+          real(r8), pointer, contiguous :: of_y(:)
+          real(r8), pointer, contiguous :: of_z(:)
+c         (write-read) virtual-position vector components
+          real(r8), pointer, contiguous :: rj_x(:)
+          real(r8), pointer, contiguous :: rj_y(:)
+          real(r8), pointer, contiguous :: rj_z(:)
+c         (write-read) relative-position vector components
+          real(r8), pointer, contiguous :: rij_x(:)
+          real(r8), pointer, contiguous :: rij_y(:)
+          real(r8), pointer, contiguous :: rij_z(:)
+c         (write-read) squared relative distances
+          real(r8), pointer, contiguous :: rij2(:)
+c         (write-read) relative distances
+          real(r8), pointer, contiguous :: rij(:)
+
+          call brute_force_dest(BFDEST_ARG)
+          call brute_force_virt(BFVIRT_ARG)
+          call brute_force_loop(BFL_ARG)
+
+          return
+        end procedure brute_force
+
+
+        module procedure brute_force_offset
+
+          call brute_force(BF_ARG)
+
+          return
+        end procedure brute_force_offset
+
+
+        module procedure brute_force_img
+          real(r8) :: offset_x
+          real(r8) :: offset_y
+          real(r8) :: offset_z
+          real(r8) :: o_x
+          real(r8) :: o_y
+          real(r8) :: o_z
+
+          offset_x = 0.0_r8
+          offset_y = 0.0_r8
+          offset_z = 0.0_r8
+
+          o_x = offset_x
+          o_y = offset_y
+          o_z = offset_z
+
+          select case (ax)
+          case ('X')
+            o_x = L
+            call brute_force_offset(particles,-o_x, o_y, o_z)
+            call brute_force_offset(particles,+o_x, o_y, o_z)
+          case ('Y')
+            o_y = L
+            call brute_force_offset(particles, o_x,-o_y, o_z)
+            call brute_force_offset(particles, o_x,+o_y, o_z)
+          case ('Z')
+            o_z = L
+            call brute_force_offset(particles, o_x, o_y,-o_z)
+            call brute_force_offset(particles, o_x, o_y,+o_z)
+          case default
+            call brute_force_offset(particles, o_x, o_y, o_z)
+          end select
+
+          return
+        end procedure brute_force_img
+
+
+        module procedure brute_force_driver
+c         (write-read) force vector components
+          real(r8), pointer, contiguous :: F_x(:)
+          real(r8), pointer, contiguous :: F_y(:)
+          real(r8), pointer, contiguous :: F_z(:)
+
+          call brute_force_driver_dest(BFDD_ARG)
+
+          F_x = 0.0_r8
+          F_y = 0.0_r8
+          F_z = 0.0_r8
+
+          call brute_force_img(particles = particles, ax = 'O')
+          call brute_force_img(particles = particles, ax = 'X')
+          call brute_force_img(particles = particles, ax = 'Y')
+          call brute_force_img(particles = particles, ax = 'Z')
+
+          call force_clamp(F_x, F_y, F_z)
+
+          return
+        end procedure brute_force_driver
+
+
+        module procedure brute_force_base
+
+          call brute_force_driver(particles)
+
+          return
+        end procedure brute_force_base
+
+      end submodule brute_force_methods
 
 *   OpenBDS                                             October 24, 2023
 *

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -56,12 +56,25 @@ c           bindings:
             procedure, public :: initialize => initializer
 c           updates the particle positions and orientations
             procedure(iupdate), deferred, public :: update
+c           implements inteparticle interactions
+            procedure(icallback), deferred, public :: callback
         end type particle_t
 
         abstract interface
           subroutine iupdate (particles)
             import particle_t
+            implicit none
             class(particle_t), intent(inout) :: particles
+          end subroutine
+        end interface
+
+        abstract interface
+          pure subroutine icallback (particles, i)
+            use, intrinsic :: iso_fortran_env, only: int64
+            import particle_t
+            implicit none
+            class(particle_t), intent(inout) :: particles
+            integer(kind = int64), intent(in) :: i
           end subroutine
         end interface
 
@@ -178,7 +191,7 @@ c         size torque vector
           integer(kind = int64), parameter :: size_t_y = N
           integer(kind = int64), parameter :: size_t_z = N
 c         size temporary placeholder
-          integer(kind = int64), parameter :: size_tmp = N
+          integer(kind = int64), parameter :: size_tmp = 12_int64 * N
 c         size Verlet neighbor-list (NOTE: we shall allocate more later)
           integer(kind = int64), parameter :: size_Vnl = N
 c         size particle identifiers IDs

--- a/api/fortran/module/vector/Makefile
+++ b/api/fortran/module/vector/Makefile
@@ -1,0 +1,25 @@
+#!/usr/bin/make
+#
+# OpenBDS						October 21, 2023
+#
+# source: api/fortran/module/vector/Makefile
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(VECTOR_O)
+
+$(VECTOR_O): $(MODULES) $(VECTOR_F)
+	$(FC) $(FCOPT) -c $(VECTOR_F) -o $(VECTOR_O) $(FMOD) $(MODS)
+
+clean:
+	/bin/rm -f *.o

--- a/api/fortran/module/vector/make-inc
+++ b/api/fortran/module/vector/make-inc
@@ -1,0 +1,27 @@
+#
+# OpenBDS						October 21, 2023
+#
+# source: api/fortran/module/vector/make-inc
+# author: @misael-diaz
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2023 Misael Diaz-Maldonado
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# modules
+CONFIG_MOD   = ../mods/config.mod
+MODULES = $(CONFIG_MOD) $(PARTICLE_MOD)
+
+# sources
+VECTOR_F = vector.f
+
+# objects
+VECTOR_O = vector.o
+
+# output directory the FORTRAN module files *.mod
+MODS = ../mods

--- a/api/fortran/module/vector/vector.f
+++ b/api/fortran/module/vector/vector.f
@@ -1,0 +1,205 @@
+      module vector
+        use, intrinsic :: iso_fortran_env, only: real64
+        use :: config, only: N => NUM_PARTICLES
+        implicit none
+        private
+        public :: vector__vec
+        public :: vector__add
+        public :: vector__diff
+        public :: vector__norm
+
+        interface vector__vec
+          module procedure vec
+        end interface
+
+        interface vector__add
+          module procedure add
+        end interface
+
+        interface vector__diff
+          module procedure diff
+        end interface
+        
+        interface vector__norm
+          module procedure norm
+        end interface
+
+      contains
+
+        pure subroutine vec (x, y, z, v_x, v_y, v_z)
+c         Synopsis:
+c         Vectorizer.
+          real(kind = real64), intent(in) :: x
+          real(kind = real64), intent(in) :: y
+          real(kind = real64), intent(in) :: z
+          real(kind = real64), intent(out) :: v_x(N)
+          real(kind = real64), intent(out) :: v_y(N)
+          real(kind = real64), intent(out) :: v_z(N)
+
+          v_x = x
+          v_y = y
+          v_z = z
+
+          return
+        end subroutine vec
+
+
+        elemental subroutine add_elem (x1, x2, x3)
+c         Synopsis:
+c         Implements vector addition.
+          real(kind = real64), intent(in) :: x1
+          real(kind = real64), intent(in) :: x2
+          real(kind = real64), intent(out) :: x3
+          
+          x3 = (x1 + x2)
+
+          return
+        end subroutine add_elem
+
+
+        elemental subroutine diff_elem (x1, x2, x3)
+c         Synopsis:
+c         Implements vector difference.
+          real(kind = real64), intent(in) :: x1
+          real(kind = real64), intent(in) :: x2
+          real(kind = real64), intent(out) :: x3
+
+          x3 = (x2 - x1)
+
+          return
+        end subroutine diff_elem
+
+
+        elemental subroutine norm_elem (x, y, z, vn)
+c         Synopsis:
+c         Implements vector norm.
+c         vector components
+          real(kind = real64), intent(in) :: x
+          real(kind = real64), intent(in) :: y
+          real(kind = real64), intent(in) :: z
+c         squared vector norm
+          real(kind = real64), intent(out) :: vn
+
+          vn = x**2 + y**2 + z**2
+
+          return
+        end subroutine norm_elem
+
+
+        pure subroutine add (
+     +    u_x,
+     +    u_y,
+     +    u_z,
+     +    v_x,
+     +    v_y,
+     +    v_z,
+     +    w_x,
+     +    w_y,
+     +    w_z
+     +  )
+c         Synopsis:
+c         Implements vector addition.
+c         components of vector v1
+          real(kind = real64), intent(in) :: u_x(N)
+          real(kind = real64), intent(in) :: u_y(N)
+          real(kind = real64), intent(in) :: u_z(N)
+c         components of vector v2
+          real(kind = real64), intent(in) :: v_x(N)
+          real(kind = real64), intent(in) :: v_y(N)
+          real(kind = real64), intent(in) :: v_z(N)
+c         components of vector v3
+          real(kind = real64), intent(out) :: w_x(N)
+          real(kind = real64), intent(out) :: w_y(N)
+          real(kind = real64), intent(out) :: w_z(N)
+
+          call add_elem(u_x, v_x, w_x)
+          call add_elem(u_y, v_y, w_y)
+          call add_elem(u_z, v_z, w_z)
+
+          return
+        end subroutine add
+
+
+        pure subroutine diff (
+     +    u_x,
+     +    u_y,
+     +    u_z,
+     +    v_x,
+     +    v_y,
+     +    v_z,
+     +    w_x,
+     +    w_y,
+     +    w_z
+     +  )
+c         Synopsis:
+c         Synopsis:
+c         Implements vector difference.
+c         components of vector v1
+          real(kind = real64), intent(in) :: u_x(N)
+          real(kind = real64), intent(in) :: u_y(N)
+          real(kind = real64), intent(in) :: u_z(N)
+c         components of vector v2
+          real(kind = real64), intent(in) :: v_x(N)
+          real(kind = real64), intent(in) :: v_y(N)
+          real(kind = real64), intent(in) :: v_z(N)
+c         components of vector v3
+          real(kind = real64), intent(out) :: w_x(N)
+          real(kind = real64), intent(out) :: w_y(N)
+          real(kind = real64), intent(out) :: w_z(N)
+
+          call diff_elem(u_x, v_x, w_x)
+          call diff_elem(u_y, v_y, w_y)
+          call diff_elem(u_z, v_z, w_z)
+
+          return
+        end subroutine diff
+
+
+        pure subroutine norm (x, y, z, squares, vnorm)
+c         Synopsis:
+c         Implements vector norm.
+c         vector components
+          real(kind = real64), intent(in) :: x(N)
+          real(kind = real64), intent(in) :: y(N)
+          real(kind = real64), intent(in) :: z(N)
+c         array temporary storing the squares (that is, x**2 + y**2 + z**2)
+          real(kind = real64), intent(out) :: squares(N)
+c         vector norm
+          real(kind = real64), intent(out) :: vnorm(N)
+
+          call norm_elem(x, y, z, squares)
+
+          vnorm = sqrt(squares)
+
+          return
+        end subroutine norm
+
+      end module vector
+
+*   OpenBDS                                             November 07, 2023
+*
+*   source: api/fortran/module/vector/vector.f
+*   author: @misael-diaz
+*
+*   Synopsis:
+*   Implements (some) vector operations.
+*
+*   Copyright (C) 2023 Misael Díaz-Maldonado
+*
+*   This program is free software: you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation, either version 3 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program. If not, see <http://www.gnu.org/licenses/>.
+*
+*   References:
+*   [0] SJ Chapman, FORTRAN for Scientists and Engineers, 4th edition.
+*   [1] MP Allen and DJ Tildesley, Computer Simulation of Liquids.
+*   [2] S Kim and S Karrila, Microhydrodynamics.

--- a/api/fortran/test/sphere/make-inc
+++ b/api/fortran/test/sphere/make-inc
@@ -32,6 +32,8 @@ TEST_SPHERE_F = tsphere.f
 # objects
 CONFIG_O   = ../../module/config/config.o
 
+VECTOR_O   = ../../module/vector/vector.o
+
 RANDOM_O   = ../../module/random/random.o
 
 PARTICLE_O = ../../module/particle/particle.o\
@@ -45,7 +47,14 @@ FORCE_O    = ../../module/force/force.o
 
 DYNAMIC_O  = ../../module/dynamic/dynamic.o
 
-OBJS = $(CONFIG_O) $(RANDOM_O) $(PARTICLE_O) $(SYSTEM_O) $(IO_O) $(FORCE_O) $(DYNAMIC_O)
+OBJS = $(CONFIG_O)\
+       $(VECTOR_O)\
+       $(RANDOM_O)\
+       $(PARTICLE_O)\
+       $(SYSTEM_O)\
+       $(IO_O)\
+       $(FORCE_O)\
+       $(DYNAMIC_O)
 
 TEST_SPHERE_O = tsphere.o
 

--- a/make-inc
+++ b/make-inc
@@ -36,12 +36,14 @@ CC = gcc
 # MAC OS X Intel FORTRAN Compiler Options
 FCOPT = -cpp -fixed -warn all -g -O0
 # Linux GNU FORTRAN Compiler Options
-FCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form
-FCOPT = -O2 -mavx -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form
+FCOPT = -O2 -mavx512vnni -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form\
+	-ffixed-line-length-none
+FCOPT = -O2 -mavx -ftree-vectorize -fopt-info-optimized=opts.log -cpp -ffixed-form\
+	-ffixed-line-length-none
 FCOPT = -g -Wall -Wextra -Waliasing -Wsurprising -Warray-bounds -Warray-temporaries\
 	-Wcharacter-truncation -Wconversion-extra -Wimplicit-interface\
 	-Wimplicit-procedure -Wuse-without-only -Wrealloc-lhs -Wrealloc-lhs-all\
-	-fcheck=all -O0 -cpp -ffixed-form
+	-fcheck=all -O0 -cpp -ffixed-form -ffixed-line-length-none
 
 # clang options
 # MAC OS X Intel C Compiler Options


### PR DESCRIPTION
COMMENTS:
refactors computations reasonably

uses MACROS for readability

GNU FORTRAN Compiler optimizes the most important loops

`destructures' the fields (or properties) of the particles object to be more explicit for the next developers, maintainers, users, and the compiler.

OBDS code executes but validation of results are pending ... so not yet ready for production in my opinion