### PR TITLE
renames real64 -> r8 [FORTRAN]

### DIFF
--- a/api/fortran/bds/OpenBDS.f
+++ b/api/fortran/bds/OpenBDS.f
@@ -1,9 +1,9 @@
-#define __SUCCESS__  0_int64
-#define __FAILURE__ -1_int64
+#define __SUCCESS__  0_i8
+#define __FAILURE__ -1_i8
 
       module OBDS
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: NUM_STEPS
         use :: config, only: NUM_LOG_STEPS
         implicit none
@@ -19,11 +19,11 @@
         pure function significand (x) result(res)
 c         Synopsis:
 c         Returns the significand (or the mantissa) of the double precision floating-point
-c         number `x' of kind `real64'.
-          real(kind = real64), intent(in) :: x
-          real(kind = real64) :: res
+c         number `x' of kind `r8'.
+          real(r8), intent(in) :: x
+          real(r8) :: res
 
-          res = 2.0_real64 * fraction(x) - 1.0_real64
+          res = 2.0_r8 * fraction(x) - 1.0_r8
 
           return
         end function significand
@@ -33,10 +33,10 @@ c         number `x' of kind `real64'.
 c         Synopsis:
 c         Returns true if `x' is an exact power of two (has an exact binary floating-point
 c         representation), returns false otherwise.
-          real(kind = real64), intent(in) :: x
-          logical(kind = int64) :: res
+          real(r8), intent(in) :: x
+          logical(i8) :: res
 
-          if (significand(x) == 0.0_real64) then
+          if (significand(x) == 0.0_r8) then
             res = .true.
           else
             res = .false.
@@ -53,10 +53,9 @@ c         Checks that the user has adhered to the design contraints on the numbe
 c         steps. Note that `NUM_STEPS' must be a multiple of `NUM_LOG_STEPS', for the
 c         OBDS loop to execute the intended number of iterations, otherwise it loops
 c         indefinitely.
-          real(kind = real64), parameter :: NUM_STEPS_REAL64 =
-     +    real(NUM_STEPS, kind = real64)
-          real(kind = real64), parameter :: NUM_LOG_STEPS_REAL64 =
-     +    real(NUM_LOG_STEPS, kind = real64)
+          real(r8), parameter :: NUM_STEPS_R8 = real(NUM_STEPS, kind=r8)
+          real(r8), parameter :: NUM_LOG_STEPS_R8 = real(NUM_LOG_STEPS,
+     +    kind = r8)
           character(*), parameter :: errmsg1 = 'sane(): '//
      +    'NUM_STEPS must be an exact power of two'
           character(*), parameter :: errmsg2 = 'sane(): '//
@@ -64,11 +63,11 @@ c         indefinitely.
           character(*), parameter :: errmsg3 = 'sane(): '//
      +    'NUM_LOG_STEPS must be less than or equal to NUM_STEPS'
 
-          if ( .not. is_pow2(NUM_STEPS_REAL64) ) then
+          if ( .not. is_pow2(NUM_STEPS_R8) ) then
             error stop errmsg1
           end if
 
-          if ( .not. is_pow2(NUM_LOG_STEPS_REAL64) ) then
+          if ( .not. is_pow2(NUM_LOG_STEPS_R8) ) then
             error stop errmsg2
           end if
 
@@ -82,8 +81,8 @@ c         indefinitely.
       end module OBDS
 
       program OpenBDS
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: NUM_STEPS
         use :: config, only: NUM_LOG_STEPS
         use :: timer,  only: timer_t
@@ -93,16 +92,16 @@ c         indefinitely.
 c       initializes pointer to collection of spheres
         type(sphere_t), pointer :: spheres => null()
         type(timer_t) :: clock
-        real(kind = real64), pointer, contiguous :: tmp(:) => null()
+        real(r8), pointer, contiguous :: tmp(:) => null()
 c       sets the number of simulation time-steps
-        integer(kind = int64), parameter :: steps = NUM_STEPS
+        integer(i8), parameter :: steps = NUM_STEPS
 c       after this many steps the OBDS code logs the particle data to a plain text file
-        integer(kind = int64), parameter :: log_steps = NUM_LOG_STEPS
+        integer(i8), parameter :: log_steps = NUM_LOG_STEPS
 c       step counters
-        integer(kind = int64) :: step
-        integer(kind = int64) :: istep
+        integer(i8) :: step
+        integer(i8) :: istep
 c       IO status
-        integer(kind = int64) :: status
+        integer(i8) :: status
 
         call sane()
 
@@ -113,7 +112,7 @@ c       IO status
 
 c       fetches the initial step number (NOTE: `sphere_t()' handles this)
         tmp => spheres % tmp
-        istep = int(tmp(1), kind = int64)
+        istep = int(tmp(1), kind = i8)
 
         step = istep
 c       executes the OBDS loop
@@ -121,14 +120,14 @@ c       loop-invariant:
 c       so far we have executed `step' OBDS simulation steps
         do while (step /= steps)
 
-          istep = 0_int64
+          istep = 0_i8
 c         loop-invariant:
 c         so far we have executed `istep' simulation steps consecutively without logging
           do while (istep /= log_steps)
 c           updates the position and orientation of the particles according to the
 c           Brownian and particle-particle interaction forces acting on them
             call spheres % update()
-            istep = istep + 1_int64
+            istep = istep + 1_i8
           end do
 
           status = spheres % flog(step + log_steps)

--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -68,8 +68,7 @@
         integer(i8), parameter :: NUM_LOG_STEPS =
      +  int(TIME_STEP_LOG / TIME_STEP, i8)
 *       clamp value, no force component shall exceed this value
-        real(r8), parameter :: CLAMP =
-     +  0.0625_r8 / TIME_STEP
+        real(r8), parameter :: CLAMP = 0.0625_r8 / TIME_STEP
 *       NOTE:
 *       The OBDS code logs the particle fields (or properties) to a    *
 *       plain text file after this (simulation) time interval has      *
@@ -83,10 +82,9 @@
 *       defines the walltime (alloted runtime for the application in   *
 *       the High Performance Computing facility HPCf in seconds)       *
         integer(i8), parameter :: WALLTIME_HRS = 164_i8
-        integer(i8), parameter :: WALLTIME_SEC = 3600_i8 *
-     +                                      WALLTIME_HRS
-        integer(i8), parameter :: WALLTIME_MILLIS =
-     +                                      1000_i8 * WALLTIME_SEC
+        integer(i8), parameter :: WALLTIME_SEC = 3600_i8 * WALLTIME_HRS
+        integer(i8), parameter :: WTS = WALLTIME_SEC
+        integer(i8), parameter :: WALLTIME_MILLIS = 1000_i8 * WTS
         integer(i8), parameter :: WALLTIME = WALLTIME_SEC
 *                                                                      *
 **                                                                    **
@@ -95,9 +93,9 @@
 **                                                                    **
 *       stores log base two of N, log2(N), where `N' is #particles     *
         integer(i8), parameter :: LOG_NUM_PARTICLES = 8_i8
+        integer(i8), parameter :: LNP = LOG_NUM_PARTICLES
 *       defines the number of particles in the system
-        integer(i8), parameter :: NUM_PARTICLES =
-     +  2_i8 ** LOG_NUM_PARTICLES
+        integer(i8), parameter :: NUM_PARTICLES = 2_i8 ** LNP
 *       NOTE:
 *       The number of particles is a power of two by design. Some of   *
 *       the algorithms that will be implemented expect the number of   *
@@ -111,12 +109,10 @@
 **                                                                    **
 *       defines the sphere radius, diameter, and contact distance      *
         real(r8), parameter :: SPH_RADIUS = 1.0_r8
-        real(r8), parameter :: SPH_DIAMETER =
-     +                                    2.0_r8 * SPH_RADIUS
+        real(r8), parameter :: SPH_DIAMETER = 2.0_r8 * SPH_RADIUS
         real(r8), parameter :: SPH_CONTACT = SPH_DIAMETER
 *       defines the interaction range for spheres                      *
-        real(r8), parameter :: SPH_INTERACT_RANGE =
-     +                                    1.5_r8 * SPH_CONTACT
+        real(r8), parameter :: SPH_INTERACT_RANGE = 1.5_r8 * SPH_CONTACT
 *       enables computation of particle-particle interactions          *
         logical(i8), parameter :: INTERACT_ENABLE = .true.
 *       NOTE:

--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -1,6 +1,6 @@
       module config
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         implicit none
         private
         save
@@ -44,10 +44,10 @@
 
 **                                                                    **
 *       system box limits and length                                   *
-        real(kind = real64), parameter :: LIMIT  = 8.0_real64
-        real(kind = real64), parameter :: LENGTH = (2.0_real64 * LIMIT)
-        real(kind = real64), parameter :: WIDTH  = LENGTH
-        real(kind = real64), parameter :: HEIGHT = LENGTH
+        real(r8), parameter :: LIMIT  = 8.0_r8
+        real(r8), parameter :: LENGTH = (2.0_r8 * LIMIT)
+        real(r8), parameter :: WIDTH  = LENGTH
+        real(r8), parameter :: HEIGHT = LENGTH
 *       NOTE:                                                          *
 *       The particle coordinates are bound to [-LIMIT, +LIMIT].        *
 **                                                                    **
@@ -55,21 +55,21 @@
 
 **                                                                    **
 *       OBDS time-step, start-time, and end-time of the simulation     *
-        real(kind = real64), parameter :: TIME_STEP = 2.0_real64**(-16)
-        real(kind = real64), parameter :: TIME_START = 0.0_real64
-        real(kind = real64), parameter :: TIME_END = 2.0_real64**4
+        real(r8), parameter :: TIME_STEP = 2.0_r8**(-16)
+        real(r8), parameter :: TIME_START = 0.0_r8
+        real(r8), parameter :: TIME_END = 2.0_r8**4
 *       OBDS logging time-step                                         *
-        real(kind = real64), parameter :: TS_LOG = 2.0_real64**(-4)
-        real(kind = real64), parameter :: TIME_STEP_LOG = TS_LOG
+        real(r8), parameter :: TS_LOG = 2.0_r8**(-4)
+        real(r8), parameter :: TIME_STEP_LOG = TS_LOG
 *       number of (simulation) steps                                   *
-        integer(kind = int64), parameter :: NUM_STEPS =
-     +  int( (TIME_END - TIME_START) / TIME_STEP, kind = int64 )
+        integer(i8), parameter :: NUM_STEPS =
+     +  int( (TIME_END - TIME_START) / TIME_STEP, i8 )
 *       after this number of steps the OBDS code logs data to a file   *
-        integer(kind = int64), parameter :: NUM_LOG_STEPS =
-     +  int(TIME_STEP_LOG / TIME_STEP, kind = int64)
+        integer(i8), parameter :: NUM_LOG_STEPS =
+     +  int(TIME_STEP_LOG / TIME_STEP, i8)
 *       clamp value, no force component shall exceed this value
-        real(kind = real64), parameter :: CLAMP =
-     +  0.0625_real64 / TIME_STEP
+        real(r8), parameter :: CLAMP =
+     +  0.0625_r8 / TIME_STEP
 *       NOTE:
 *       The OBDS code logs the particle fields (or properties) to a    *
 *       plain text file after this (simulation) time interval has      *
@@ -82,22 +82,22 @@
 **                                                                    **
 *       defines the walltime (alloted runtime for the application in   *
 *       the High Performance Computing facility HPCf in seconds)       *
-        integer(kind = int64), parameter :: WALLTIME_HRS = 164_int64
-        integer(kind = int64), parameter :: WALLTIME_SEC = 3600_int64 *
+        integer(i8), parameter :: WALLTIME_HRS = 164_i8
+        integer(i8), parameter :: WALLTIME_SEC = 3600_i8 *
      +                                      WALLTIME_HRS
-        integer(kind = int64), parameter :: WALLTIME_MILLIS =
-     +                                      1000_int64 * WALLTIME_SEC
-        integer(kind = int64), parameter :: WALLTIME = WALLTIME_SEC
+        integer(i8), parameter :: WALLTIME_MILLIS =
+     +                                      1000_i8 * WALLTIME_SEC
+        integer(i8), parameter :: WALLTIME = WALLTIME_SEC
 *                                                                      *
 **                                                                    **
 
 
 **                                                                    **
 *       stores log base two of N, log2(N), where `N' is #particles     *
-        integer(kind = int64), parameter :: LOG_NUM_PARTICLES = 8_int64
+        integer(i8), parameter :: LOG_NUM_PARTICLES = 8_i8
 *       defines the number of particles in the system
-        integer(kind = int64), parameter :: NUM_PARTICLES =
-     +  2_int64 ** LOG_NUM_PARTICLES
+        integer(i8), parameter :: NUM_PARTICLES =
+     +  2_i8 ** LOG_NUM_PARTICLES
 *       NOTE:
 *       The number of particles is a power of two by design. Some of   *
 *       the algorithms that will be implemented expect the number of   *
@@ -110,15 +110,15 @@
 
 **                                                                    **
 *       defines the sphere radius, diameter, and contact distance      *
-        real(kind = real64), parameter :: SPH_RADIUS = 1.0_real64
-        real(kind = real64), parameter :: SPH_DIAMETER =
-     +                                    2.0_real64 * SPH_RADIUS
-        real(kind = real64), parameter :: SPH_CONTACT = SPH_DIAMETER
+        real(r8), parameter :: SPH_RADIUS = 1.0_r8
+        real(r8), parameter :: SPH_DIAMETER =
+     +                                    2.0_r8 * SPH_RADIUS
+        real(r8), parameter :: SPH_CONTACT = SPH_DIAMETER
 *       defines the interaction range for spheres                      *
-        real(kind = real64), parameter :: SPH_INTERACT_RANGE =
-     +                                    1.5_real64 * SPH_CONTACT
+        real(r8), parameter :: SPH_INTERACT_RANGE =
+     +                                    1.5_r8 * SPH_CONTACT
 *       enables computation of particle-particle interactions          *
-        logical(kind = int64), parameter :: INTERACT_ENABLE = .true.
+        logical(i8), parameter :: INTERACT_ENABLE = .true.
 *       NOTE:
 *       Reasons for disabling particle interactions are code profiling *
 *       and validating the statistics of the normally-distributed      *

--- a/api/fortran/module/dynamic/dynamic.f
+++ b/api/fortran/module/dynamic/dynamic.f
@@ -1,5 +1,5 @@
       module dynamic
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: dt => TIME_STEP
         use :: config, only: N => NUM_PARTICLES
         use :: particle, only: particle_t
@@ -18,9 +18,9 @@ c         Synopsis:
 c         Shifts the particles in the direction of the Brownian force.
 c         NOTE:
 c         This only applies to spheres. The isotropic hydrodynamic resistance is implied.
-          real(kind = real64), intent(in) :: mobility
-          real(kind = real64), intent(out) :: x(N)
-          real(kind = real64), intent(in) :: F_x(N)
+          real(r8), intent(in) :: mobility
+          real(r8), intent(out) :: x(N)
+          real(r8), intent(in) :: F_x(N)
 
           x = x + mobility * F_x
 
@@ -35,14 +35,14 @@ c         NOTE:
 c         This code only applies to spheres. We shall overload this method later
 c         with a callback, as in the clang API, to handle anisotropic particles.
           class(particle_t), intent(inout), target :: particles
-          real(kind = real64), pointer, contiguous :: x(:) => null()
-          real(kind = real64), pointer, contiguous :: y(:) => null()
-          real(kind = real64), pointer, contiguous :: z(:) => null()
-          real(kind = real64), pointer, contiguous :: F_x(:) => null()
-          real(kind = real64), pointer, contiguous :: F_y(:) => null()
-          real(kind = real64), pointer, contiguous :: F_z(:) => null()
-          real(kind = real64), parameter :: m = sqrt(2.0_real64 * dt)
-          real(kind = real64), parameter :: mobility = m
+          real(r8), pointer, contiguous :: x(:) => null()
+          real(r8), pointer, contiguous :: y(:) => null()
+          real(r8), pointer, contiguous :: z(:) => null()
+          real(r8), pointer, contiguous :: F_x(:) => null()
+          real(r8), pointer, contiguous :: F_y(:) => null()
+          real(r8), pointer, contiguous :: F_z(:) => null()
+          real(r8), parameter :: m = sqrt(2.0_r8 * dt)
+          real(r8), parameter :: mobility = m
 
           F_x => particles % F_x
           F_y => particles % F_y

--- a/api/fortran/module/io/io.f
+++ b/api/fortran/module/io/io.f
@@ -1,12 +1,11 @@
-#define __SUCCESS__  0_int64
-#define __FAILURE__ -1_int64
+#define __SUCCESS__  0_i8
+#define __FAILURE__ -1_i8
 #define __FNAME_LENGTH__ 256
 
       module io
         use, intrinsic :: iso_fortran_env, only: r8 => real64
-        use, intrinsic :: iso_fortran_env, only: real64
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: int32
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: i4 => int32
 #if defined(__INTEL_COMPILER)
 c       uses Intel FORTRAN Portability `IFPORT' Module if we are not compiling with the
 c       GNU FORTRAN Compiler, this is needed because `rename()` is a GNU Extension
@@ -58,31 +57,31 @@ c         Synopsis:
 c         Binds pointers to their respective particle fields.
           class(particle_t), intent(in), target :: particles
 c         position vector components subject to periodic conditions
-          real(kind = r8), pointer, contiguous, intent(inout) :: x(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: y(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: z(:)
+          real(r8), pointer, contiguous, intent(inout) :: x(:)
+          real(r8), pointer, contiguous, intent(inout) :: y(:)
+          real(r8), pointer, contiguous, intent(inout) :: z(:)
 c         position vector components independent of periodic conditions
-          real(kind = r8), pointer, contiguous, intent(inout) :: r_x(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: r_y(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: r_z(:)
+          real(r8), pointer, contiguous, intent(inout) :: r_x(:)
+          real(r8), pointer, contiguous, intent(inout) :: r_y(:)
+          real(r8), pointer, contiguous, intent(inout) :: r_z(:)
 c         Euler angle vector components
-          real(kind = r8), pointer, contiguous, intent(inout) :: Eax(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: Eay(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: Eaz(:)
+          real(r8), pointer, contiguous, intent(inout) :: Eax(:)
+          real(r8), pointer, contiguous, intent(inout) :: Eay(:)
+          real(r8), pointer, contiguous, intent(inout) :: Eaz(:)
 c         director (or orientation vector) components
-          real(kind = r8), pointer, contiguous, intent(inout) :: d_x(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: d_y(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: d_z(:)
+          real(r8), pointer, contiguous, intent(inout) :: d_x(:)
+          real(r8), pointer, contiguous, intent(inout) :: d_y(:)
+          real(r8), pointer, contiguous, intent(inout) :: d_z(:)
 c         force vector components
-          real(kind = r8), pointer, contiguous, intent(inout) :: F_x(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: F_y(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: F_z(:)
+          real(r8), pointer, contiguous, intent(inout) :: F_x(:)
+          real(r8), pointer, contiguous, intent(inout) :: F_y(:)
+          real(r8), pointer, contiguous, intent(inout) :: F_z(:)
 c         torque vector components
-          real(kind = r8), pointer, contiguous, intent(inout) :: T_x(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: T_y(:)
-          real(kind = r8), pointer, contiguous, intent(inout) :: T_z(:)
+          real(r8), pointer, contiguous, intent(inout) :: T_x(:)
+          real(r8), pointer, contiguous, intent(inout) :: T_y(:)
+          real(r8), pointer, contiguous, intent(inout) :: T_z(:)
 c         identifiers IDs
-          real(kind = r8), pointer, contiguous, intent(inout) :: id(:)
+          real(r8), pointer, contiguous, intent(inout) :: id(:)
 
           x => particles % x
           y => particles % y
@@ -117,8 +116,8 @@ c         identifiers IDs
         function fstatus (IOSTAT) result(STATUS)
 c         Synopsis:
 c         Sets `STATUS' based on the value stored in `IOSTAT'.
-          integer(kind = int64), intent(in) :: IOSTAT
-          integer(kind = int64) :: STATUS
+          integer(i8), intent(in) :: IOSTAT
+          integer(i8) :: STATUS
 
           if (IOSTAT == __SUCCESS__) then
             STATUS = __SUCCESS__
@@ -137,10 +136,10 @@ c         On success (failure) the file descriptor `fd' is set (unknown).
 c         Returns the status of this operation to the caller.
           character(len=__FNAME_LENGTH__), intent(in) :: filename
 c         file descriptor
-          integer(kind = int64), intent(out) :: fd
+          integer(i8), intent(out) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 
           open(newunit = fd,
      +         file = trim(filename),
@@ -163,10 +162,10 @@ c         On success (failure) the file descriptor `fd' is set (unknown).
 c         Returns the status of this operation to the caller.
           character(len=__FNAME_LENGTH__), intent(in) :: filename
 c         file descriptor
-          integer(kind = int64), intent(out) :: fd
+          integer(i8), intent(out) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 
           open(newunit = fd,
      +         file = trim(filename),
@@ -189,10 +188,10 @@ c         On success (failure) the file descriptor `fd' is set (unknown).
 c         Returns the status of this operation to the caller.
           character(len=__FNAME_LENGTH__), intent(in) :: filename
 c         file descriptor
-          integer(kind = int64), intent(out) :: fd
+          integer(i8), intent(out) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 
           open(newunit = fd,
      +         file = trim(filename),
@@ -218,9 +217,9 @@ c         On success (failure) the file descriptor `fd' is set (unknown).
 c         Returns the status of this operation to the caller.
           character(len=__FNAME_LENGTH__), intent(in) :: filename
 c         file descriptor
-          integer(kind = int64), intent(out) :: fd
+          integer(i8), intent(out) :: fd
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
           character(len=1), intent(in), optional :: action
 
           if ( present(action) ) then
@@ -247,10 +246,10 @@ c         IO status
 c         Synopsis:
 c         Closes the file associated with the file descriptor `fd'.
 c         Returns the status of this operation to the caller.
-          integer(kind = int64), intent(in) :: fd
+          integer(i8), intent(in) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 
           close(unit = fd, iostat = iostat)
 
@@ -272,38 +271,38 @@ c         Synopsis:
 c         Logs the particle fields (or properties).
 c         Returns the status of this operation to the caller.
 c         position vector components subject to periodic conditions
-          real(kind = real64), intent(in) :: x(N)
-          real(kind = real64), intent(in) :: y(N)
-          real(kind = real64), intent(in) :: z(N)
+          real(r8), intent(in) :: x(N)
+          real(r8), intent(in) :: y(N)
+          real(r8), intent(in) :: z(N)
 c         position vector components independent of periodic conditions
-          real(kind = real64), intent(in) :: r_x(N)
-          real(kind = real64), intent(in) :: r_y(N)
-          real(kind = real64), intent(in) :: r_z(N)
+          real(r8), intent(in) :: r_x(N)
+          real(r8), intent(in) :: r_y(N)
+          real(r8), intent(in) :: r_z(N)
 c         Euler angle vector components
-          real(kind = real64), intent(in) :: Eax(N)
-          real(kind = real64), intent(in) :: Eay(N)
-          real(kind = real64), intent(in) :: Eaz(N)
+          real(r8), intent(in) :: Eax(N)
+          real(r8), intent(in) :: Eay(N)
+          real(r8), intent(in) :: Eaz(N)
 c         director (or orientation vector) components
-          real(kind = real64), intent(in) :: d_x(N)
-          real(kind = real64), intent(in) :: d_y(N)
-          real(kind = real64), intent(in) :: d_z(N)
+          real(r8), intent(in) :: d_x(N)
+          real(r8), intent(in) :: d_y(N)
+          real(r8), intent(in) :: d_z(N)
 c         force vector components
-          real(kind = real64), intent(in) :: F_x(N)
-          real(kind = real64), intent(in) :: F_y(N)
-          real(kind = real64), intent(in) :: F_z(N)
+          real(r8), intent(in) :: F_x(N)
+          real(r8), intent(in) :: F_y(N)
+          real(r8), intent(in) :: F_z(N)
 c         torque vector components
-          real(kind = real64), intent(in) :: T_x(N)
-          real(kind = real64), intent(in) :: T_y(N)
-          real(kind = real64), intent(in) :: T_z(N)
+          real(r8), intent(in) :: T_x(N)
+          real(r8), intent(in) :: T_y(N)
+          real(r8), intent(in) :: T_z(N)
 c         identifiers IDs
-          real(kind = real64), intent(in) :: id(N)
+          real(r8), intent(in) :: id(N)
 c         file descriptor
-          integer(kind = int64), intent(in) :: fd
+          integer(i8), intent(in) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         loop index
-          integer(kind = int64) :: i
+          integer(i8) :: i
 c         format `fmt' specifier, NEw.d
           character(*), parameter :: fmt = '(SP,19E32.16)'
 c         NOTE:
@@ -313,7 +312,7 @@ c         E: exponential (or scientific) format
 c         w: width, 25 positions
 c         d: digits after the decimal place, 16 digits
 
-          do i = 1_int64, N
+          do i = 1_i8, N
             write(unit = fd, fmt = fmt, iostat = iostat)
      +        x(i), y(i), z(i),      ! position vector
      +        r_x(i), r_y(i), r_z(i),! `absolute' position vector
@@ -343,38 +342,38 @@ c         Loads the particle fields (or properties) from the data file whose fil
 c         descriptor is `fd'.
 c         Returns the status of this operation to the caller.
 c         position vector components subject to periodic conditions
-          real(kind = real64), intent(out) :: x(N)
-          real(kind = real64), intent(out) :: y(N)
-          real(kind = real64), intent(out) :: z(N)
+          real(r8), intent(out) :: x(N)
+          real(r8), intent(out) :: y(N)
+          real(r8), intent(out) :: z(N)
 c         position vector components independent of periodic conditions
-          real(kind = real64), intent(out) :: r_x(N)
-          real(kind = real64), intent(out) :: r_y(N)
-          real(kind = real64), intent(out) :: r_z(N)
+          real(r8), intent(out) :: r_x(N)
+          real(r8), intent(out) :: r_y(N)
+          real(r8), intent(out) :: r_z(N)
 c         Euler angle vector components
-          real(kind = real64), intent(out) :: Eax(N)
-          real(kind = real64), intent(out) :: Eay(N)
-          real(kind = real64), intent(out) :: Eaz(N)
+          real(r8), intent(out) :: Eax(N)
+          real(r8), intent(out) :: Eay(N)
+          real(r8), intent(out) :: Eaz(N)
 c         director (or orientation vector) components
-          real(kind = real64), intent(out) :: d_x(N)
-          real(kind = real64), intent(out) :: d_y(N)
-          real(kind = real64), intent(out) :: d_z(N)
+          real(r8), intent(out) :: d_x(N)
+          real(r8), intent(out) :: d_y(N)
+          real(r8), intent(out) :: d_z(N)
 c         force vector components
-          real(kind = real64), intent(out) :: F_x(N)
-          real(kind = real64), intent(out) :: F_y(N)
-          real(kind = real64), intent(out) :: F_z(N)
+          real(r8), intent(out) :: F_x(N)
+          real(r8), intent(out) :: F_y(N)
+          real(r8), intent(out) :: F_z(N)
 c         torque vector components
-          real(kind = real64), intent(out) :: T_x(N)
-          real(kind = real64), intent(out) :: T_y(N)
-          real(kind = real64), intent(out) :: T_z(N)
+          real(r8), intent(out) :: T_x(N)
+          real(r8), intent(out) :: T_y(N)
+          real(r8), intent(out) :: T_z(N)
 c         identifiers IDs
-          real(kind = real64), intent(out) :: id(N)
+          real(r8), intent(out) :: id(N)
 c         file descriptor
-          integer(kind = int64), intent(in) :: fd
+          integer(i8), intent(in) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         loop index
-          integer(kind = int64) :: i
+          integer(i8) :: i
 c         format `fmt' specifier, NEw.d
           character(*), parameter :: fmt = '(SP,19E32.16)'
 c         NOTE:
@@ -384,7 +383,7 @@ c         E: exponential (or scientific) format
 c         w: width, 25 positions
 c         d: digits after the decimal place, 16 digits
 
-          do i = 1_int64, N
+          do i = 1_i8, N
             read(unit = fd, fmt = fmt, iostat = iostat)
      +        x(i), y(i), z(i),      ! position vector
      +        r_x(i), r_y(i), r_z(i),! `absolute' position vector
@@ -408,35 +407,35 @@ c         file descriptor `fd'.
 c         Returns the status of this operation to the caller.
           class(particle_t), intent(in), target :: particles
 c         file descriptor
-          integer(kind = int64), intent(in) :: fd
+          integer(i8), intent(in) :: fd
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 c         position vector components subject to periodic conditions
-          real(kind = real64), pointer, contiguous :: x(:) => null()
-          real(kind = real64), pointer, contiguous :: y(:) => null()
-          real(kind = real64), pointer, contiguous :: z(:) => null()
+          real(r8), pointer, contiguous :: x(:) => null()
+          real(r8), pointer, contiguous :: y(:) => null()
+          real(r8), pointer, contiguous :: z(:) => null()
 c         position vector components independent of periodic conditions
-          real(kind = real64), pointer, contiguous :: r_x(:) => null()
-          real(kind = real64), pointer, contiguous :: r_y(:) => null()
-          real(kind = real64), pointer, contiguous :: r_z(:) => null()
+          real(r8), pointer, contiguous :: r_x(:) => null()
+          real(r8), pointer, contiguous :: r_y(:) => null()
+          real(r8), pointer, contiguous :: r_z(:) => null()
 c         Euler angle vector components
-          real(kind = real64), pointer, contiguous :: Eax(:) => null()
-          real(kind = real64), pointer, contiguous :: Eay(:) => null()
-          real(kind = real64), pointer, contiguous :: Eaz(:) => null()
+          real(r8), pointer, contiguous :: Eax(:) => null()
+          real(r8), pointer, contiguous :: Eay(:) => null()
+          real(r8), pointer, contiguous :: Eaz(:) => null()
 c         director (or orientation vector) components
-          real(kind = real64), pointer, contiguous :: d_x(:) => null()
-          real(kind = real64), pointer, contiguous :: d_y(:) => null()
-          real(kind = real64), pointer, contiguous :: d_z(:) => null()
+          real(r8), pointer, contiguous :: d_x(:) => null()
+          real(r8), pointer, contiguous :: d_y(:) => null()
+          real(r8), pointer, contiguous :: d_z(:) => null()
 c         force vector components
-          real(kind = real64), pointer, contiguous :: F_x(:) => null()
-          real(kind = real64), pointer, contiguous :: F_y(:) => null()
-          real(kind = real64), pointer, contiguous :: F_z(:) => null()
+          real(r8), pointer, contiguous :: F_x(:) => null()
+          real(r8), pointer, contiguous :: F_y(:) => null()
+          real(r8), pointer, contiguous :: F_z(:) => null()
 c         torque vector components
-          real(kind = real64), pointer, contiguous :: T_x(:) => null()
-          real(kind = real64), pointer, contiguous :: T_y(:) => null()
-          real(kind = real64), pointer, contiguous :: T_z(:) => null()
+          real(r8), pointer, contiguous :: T_x(:) => null()
+          real(r8), pointer, contiguous :: T_y(:) => null()
+          real(r8), pointer, contiguous :: T_z(:) => null()
 c         identifiers IDs
-          real(kind = real64), pointer, contiguous :: id(:) => null()
+          real(r8), pointer, contiguous :: id(:) => null()
 
           call bind(x, y, z,
      +              r_x, r_y, r_z,
@@ -465,35 +464,35 @@ c         the file descriptor `fd'.
 c         Returns the status of this operation to the caller.
           class(particle_t), intent(inout), target :: particles
 c         file descriptor
-          integer(kind = int64), intent(in) :: fd
+          integer(i8), intent(in) :: fd
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 c         position vector components subject to periodic conditions
-          real(kind = real64), pointer, contiguous :: x(:) => null()
-          real(kind = real64), pointer, contiguous :: y(:) => null()
-          real(kind = real64), pointer, contiguous :: z(:) => null()
+          real(r8), pointer, contiguous :: x(:) => null()
+          real(r8), pointer, contiguous :: y(:) => null()
+          real(r8), pointer, contiguous :: z(:) => null()
 c         position vector components independent of periodic conditions
-          real(kind = real64), pointer, contiguous :: r_x(:) => null()
-          real(kind = real64), pointer, contiguous :: r_y(:) => null()
-          real(kind = real64), pointer, contiguous :: r_z(:) => null()
+          real(r8), pointer, contiguous :: r_x(:) => null()
+          real(r8), pointer, contiguous :: r_y(:) => null()
+          real(r8), pointer, contiguous :: r_z(:) => null()
 c         Euler angle vector components
-          real(kind = real64), pointer, contiguous :: Eax(:) => null()
-          real(kind = real64), pointer, contiguous :: Eay(:) => null()
-          real(kind = real64), pointer, contiguous :: Eaz(:) => null()
+          real(r8), pointer, contiguous :: Eax(:) => null()
+          real(r8), pointer, contiguous :: Eay(:) => null()
+          real(r8), pointer, contiguous :: Eaz(:) => null()
 c         director (or orientation vector) components
-          real(kind = real64), pointer, contiguous :: d_x(:) => null()
-          real(kind = real64), pointer, contiguous :: d_y(:) => null()
-          real(kind = real64), pointer, contiguous :: d_z(:) => null()
+          real(r8), pointer, contiguous :: d_x(:) => null()
+          real(r8), pointer, contiguous :: d_y(:) => null()
+          real(r8), pointer, contiguous :: d_z(:) => null()
 c         force vector components
-          real(kind = real64), pointer, contiguous :: F_x(:) => null()
-          real(kind = real64), pointer, contiguous :: F_y(:) => null()
-          real(kind = real64), pointer, contiguous :: F_z(:) => null()
+          real(r8), pointer, contiguous :: F_x(:) => null()
+          real(r8), pointer, contiguous :: F_y(:) => null()
+          real(r8), pointer, contiguous :: F_z(:) => null()
 c         torque vector components
-          real(kind = real64), pointer, contiguous :: T_x(:) => null()
-          real(kind = real64), pointer, contiguous :: T_y(:) => null()
-          real(kind = real64), pointer, contiguous :: T_z(:) => null()
+          real(r8), pointer, contiguous :: T_x(:) => null()
+          real(r8), pointer, contiguous :: T_y(:) => null()
+          real(r8), pointer, contiguous :: T_z(:) => null()
 c         identifiers IDs
-          real(kind = real64), pointer, contiguous :: id(:) => null()
+          real(r8), pointer, contiguous :: id(:) => null()
 
           call bind(x, y, z,
      +              r_x, r_y, r_z,
@@ -521,12 +520,12 @@ c         Logs the current particle fields (or properties).
 c         Returns the status of this operation to the caller.
           class(particle_t), intent(in) :: particles
 c         OBDS simulation step number (or identifier)
-          integer(kind = int64), intent(in) :: step
+          integer(i8), intent(in) :: step
 c         file descriptor
-          integer(kind = int64) :: fd
+          integer(i8) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         placeholder to store the step number in a string
           character(len = 64) :: step_str
 c         temporary filename
@@ -574,7 +573,7 @@ c         NOTE:
 c         This is so that we know for sure during post-processing that the data was
 c         written successfully (we won't need to worry about data corruption due to
 c         IO errors).
-          iostat = int(rename(tempname, filename), kind = int64)
+          iostat = int(rename(tempname, filename), kind = i8)
           status = fstatus(iostat)
           if (STATUS == __FAILURE__) then
             print *, 'UNEXPECTED IO ERROR with file: ', trim(filename)
@@ -592,11 +591,11 @@ c         step number is `step'.
 c         Returns the status of this operation to the caller.
           class(particle_t), intent(inout) :: particles
 c         OBDS simulation step number (or identifier)
-          integer(kind = int64), intent(in) :: step
+          integer(i8), intent(in) :: step
 c         file descriptor
-          integer(kind = int64) :: fd
+          integer(i8) :: fd
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 c         placeholder to store the step number in a string
           character(len = 64) :: step_str
 c         name of data file containing the particle fields (or properties)
@@ -644,12 +643,12 @@ c         Synopsis:
 c         Dumps the last known system state to the state file, where the `state' is
 c         the last known simulation step number.
 c         Returns the status of this operation to the caller.
-          integer(kind = int64), intent(in) :: istate
+          integer(i8), intent(in) :: istate
 c         file descriptor
-          integer(kind = int64) :: fd
+          integer(i8) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         name of the state file
           character(len = __FNAME_LENGTH__), parameter :: fname =
      +    'run/bds/state/state.txt'
@@ -697,12 +696,12 @@ c         we are successful in dumping a status. This is done by
 c         renaming the status file from its temporary name to its
 c         designated name. It is better to err on the safe side than
 c         to cause a job-scheduling hell.
-          integer(kind = int32), intent(in) :: stat
+          integer(i4), intent(in) :: stat
 c         file descriptor
-          integer(kind = int64) :: fd
+          integer(i8) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         temporary status file
           character(len = __FNAME_LENGTH__), parameter :: tname =
      +    'run/bds/status/status.tmp'
@@ -745,7 +744,7 @@ c         closes the file temporary
           end if
 
 c         commits the status
-          iostat = int(rename(tname, fname), kind = int64)
+          iostat = int(rename(tname, fname), kind = i8)
           status = fstatus(iostat)
           if (STATUS == __FAILURE__) then
             print *, 'UNEXPECTED IO ERROR with file: ', trim(fname)
@@ -761,14 +760,14 @@ c         Synopsis:
 c         Fetches the last known state from the state file.
 c         Returns the status of this operation to the caller.
 c         state (or step number) stored in a double precision floating-point number
-          real(kind = real64), intent(out) :: state
+          real(r8), intent(out) :: state
 c         file descriptor
-          integer(kind = int64) :: fd
+          integer(i8) :: fd
 c         IO status
-          integer(kind = int64) :: status
-          integer(kind = int64) :: iostat
+          integer(i8) :: status
+          integer(i8) :: iostat
 c         state (or step number)
-          integer(kind = int64) :: istate
+          integer(i8) :: istate
 c         name of the state file
           character(len = __FNAME_LENGTH__), parameter :: fname =
      +    'run/bds/state/state.txt'
@@ -786,7 +785,7 @@ c         in the state file in the next codeblocks
           if (STATUS == __FAILURE__) then
             print *, 'IO ERROR with file: ', trim(fname)
             print *, 'initializing state with its default value'
-            state = 0.0_real64 ! zeros intent(out) argument (default)
+            state = 0.0_r8 ! zeros intent(out) argument (default)
             return
           end if
 
@@ -798,7 +797,7 @@ c         queries the IO status
           if (STATUS == __FAILURE__) then
             print *, 'UNEXPECTED READ ERROR with file: ', trim(fname)
             print *, 'initializing state with its default value'
-            state = 0.0_real64 ! zeros intent(out) argument (default)
+            state = 0.0_r8 ! zeros intent(out) argument (default)
             close(fd)
             return
           end if
@@ -807,7 +806,7 @@ c         sets the state with the fecthed value
 c         NOTE:
 c         applies an upper bound on the `state' (step number) to guard
 c         against invalid inputs (even if unlikely)
-          state = real( min(istate, NUM_STEPS), kind = real64 )
+          state = real( min(istate, NUM_STEPS), kind = r8 )
 
 c         closes the file
           status = fclose(fd)
@@ -825,9 +824,9 @@ c         Synopsis:
 c         Dumps the OBDS state (holds the simulation step number) to the state file.
 c         Returns the status of this operation to the caller.
 c         system state (stands for the simulation step number)
-          integer(kind = int64), intent(in) :: istate
+          integer(i8), intent(in) :: istate
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 
           status = fdump_state(istate)
 
@@ -841,11 +840,11 @@ c         Fetches the OBDS state (holds the simulation step number) from the sta
 c         Returns the status of this operation to the caller.
           class(particle_t), intent(inout), target :: particles
 c         temporary placeholder array
-          real(kind = real64), pointer, contiguous :: tmp(:) => null()
+          real(r8), pointer, contiguous :: tmp(:) => null()
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 c         system state (stands for the simulation step number)
-          real(kind = real64) :: state
+          real(r8) :: state
 
           status = ffetch_state(state)
 
@@ -866,9 +865,9 @@ c         Synopsis:
 c         Dumps the OBDS status to the status file to implement auto-scheduling.
 c         Returns the status of this operation to the caller.
 c         status of the simulation either (DONE, PENDING, or UNKNOWN)
-          integer(kind = int32), intent(in) :: stat
+          integer(i4), intent(in) :: stat
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 
           status = fdump_status(stat)
 

--- a/api/fortran/module/particle/particle.f
+++ b/api/fortran/module/particle/particle.f
@@ -1,9 +1,9 @@
-#define __PASS__  0_int64
-#define __FAIL__ -1_int64
+#define __PASS__  0_i8
+#define __FAIL__ -1_i8
 
       module particle
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: LOG_NUM_PARTICLES
         use :: config, only: NUM_PARTICLES
         use :: config, only: TIME_STEP
@@ -13,41 +13,41 @@
 
         type, abstract, public :: particle_t
 c         position vector components (subjected to periodic conditions)
-          real(kind = real64), pointer, contiguous :: x(:) => null()
-          real(kind = real64), pointer, contiguous :: y(:) => null()
-          real(kind = real64), pointer, contiguous :: z(:) => null()
+          real(r8), pointer, contiguous :: x(:) => null()
+          real(r8), pointer, contiguous :: y(:) => null()
+          real(r8), pointer, contiguous :: z(:) => null()
 c         Verlet displacement vector components
-          real(kind = real64), pointer, contiguous :: Vdx(:) => null()
-          real(kind = real64), pointer, contiguous :: Vdy(:) => null()
-          real(kind = real64), pointer, contiguous :: Vdz(:) => null()
+          real(r8), pointer, contiguous :: Vdx(:) => null()
+          real(r8), pointer, contiguous :: Vdy(:) => null()
+          real(r8), pointer, contiguous :: Vdz(:) => null()
 c         position vector components (periodic conditions independent)
-          real(kind = real64), pointer, contiguous :: r_x(:) => null()
-          real(kind = real64), pointer, contiguous :: r_y(:) => null()
-          real(kind = real64), pointer, contiguous :: r_z(:) => null()
+          real(r8), pointer, contiguous :: r_x(:) => null()
+          real(r8), pointer, contiguous :: r_y(:) => null()
+          real(r8), pointer, contiguous :: r_z(:) => null()
 c         Euler angle vector components
-          real(kind = real64), pointer, contiguous :: Eax(:) => null()
-          real(kind = real64), pointer, contiguous :: Eay(:) => null()
-          real(kind = real64), pointer, contiguous :: Eaz(:) => null()
+          real(r8), pointer, contiguous :: Eax(:) => null()
+          real(r8), pointer, contiguous :: Eay(:) => null()
+          real(r8), pointer, contiguous :: Eaz(:) => null()
 c         orientation (or director) vector components
-          real(kind = real64), pointer, contiguous :: d_x(:) => null()
-          real(kind = real64), pointer, contiguous :: d_y(:) => null()
-          real(kind = real64), pointer, contiguous :: d_z(:) => null()
+          real(r8), pointer, contiguous :: d_x(:) => null()
+          real(r8), pointer, contiguous :: d_y(:) => null()
+          real(r8), pointer, contiguous :: d_z(:) => null()
 c         force vector components
-          real(kind = real64), pointer, contiguous :: f_x(:) => null()
-          real(kind = real64), pointer, contiguous :: f_y(:) => null()
-          real(kind = real64), pointer, contiguous :: f_z(:) => null()
+          real(r8), pointer, contiguous :: f_x(:) => null()
+          real(r8), pointer, contiguous :: f_y(:) => null()
+          real(r8), pointer, contiguous :: f_z(:) => null()
 c         torque vector components
-          real(kind = real64), pointer, contiguous :: t_x(:) => null()
-          real(kind = real64), pointer, contiguous :: t_y(:) => null()
-          real(kind = real64), pointer, contiguous :: t_z(:) => null()
+          real(r8), pointer, contiguous :: t_x(:) => null()
+          real(r8), pointer, contiguous :: t_y(:) => null()
+          real(r8), pointer, contiguous :: t_z(:) => null()
 c         temporary placeholder
-          real(kind = real64), pointer, contiguous :: tmp(:) => null()
+          real(r8), pointer, contiguous :: tmp(:) => null()
 c         Verlet neighbor-list
-          real(kind = real64), pointer, contiguous :: Vnl(:) => null()
+          real(r8), pointer, contiguous :: Vnl(:) => null()
 c         particle identifiers IDs
-          real(kind = real64), pointer, contiguous :: id(:) => null()
+          real(r8), pointer, contiguous :: id(:) => null()
 c         data placeholder
-          real(kind = real64), pointer, contiguous :: data(:) => null()
+          real(r8), pointer, contiguous :: data(:) => null()
           contains
             private
 c           memory allocations and initializations
@@ -70,19 +70,19 @@ c           implements inteparticle interactions
 
         abstract interface
           pure subroutine icallback (particles, i)
-            use, intrinsic :: iso_fortran_env, only: int64
+            use, intrinsic :: iso_fortran_env, only: i8 => int64
             import particle_t
             implicit none
             class(particle_t), intent(inout) :: particles
-            integer(kind = int64), intent(in) :: i
+            integer(i8), intent(in) :: i
           end subroutine
         end interface
 
       contains
 
         pure function test (t) result(outcome)
-          logical(kind = int64), intent(in) :: t
-          integer(kind = int64) :: outcome
+          logical(i8), intent(in) :: t
+          integer(i8) :: outcome
 
           if (t) then
             outcome = __PASS__
@@ -97,17 +97,17 @@ c           implements inteparticle interactions
         subroutine sane ()
 c         Synopsis:
 c         Complains if the module parameters in `config` are illegal.
-          integer(kind = int64), parameter :: N = NUM_PARTICLES
-          integer(kind = int64), parameter :: LOG_N = LOG_NUM_PARTICLES
-          integer(kind = int64), parameter :: E = LOG_N ! Exponent
-          real(kind = real64), parameter :: L = LIMIT
-          real(kind = real64), parameter :: T = TIME_STEP
+          integer(i8), parameter :: N = NUM_PARTICLES
+          integer(i8), parameter :: LOG_N = LOG_NUM_PARTICLES
+          integer(i8), parameter :: E = LOG_N ! Exponent
+          real(r8), parameter :: L = LIMIT
+          real(r8), parameter :: T = TIME_STEP
 c         tests that the number of particles is an exact power of two
-          logical(kind = int64), parameter :: t1 = (N == 2_int64 ** E)
+          logical(i8), parameter :: t1 = (N == 2_i8 ** E)
 c         tests that the system limit is positive
-          logical(kind = int64), parameter :: t2 = (L > 0.0_real64)
+          logical(i8), parameter :: t2 = (L > 0.0_r8)
 c         tests that the time-step is positive
-          logical(kind = int64), parameter :: t3 = (T > 0.0_real64)
+          logical(i8), parameter :: t3 = (T > 0.0_r8)
 c         defines the error messages
           character(*), parameter :: e1 = "particle::sane(): " //
      +    "IllegalParameterError: the number of particles is not a " //
@@ -137,12 +137,12 @@ c         defines the error messages
 c         Synopsis:
 c         implements a std::iota C++ like method
 c         fills array `x' with values in symmetric range [1, numel]
-          integer(kind = int64), parameter :: numel = NUM_PARTICLES
-          real(kind = real64), intent(out) :: x(numel)
-          integer(kind = int64) :: i
+          integer(i8), parameter :: numel = NUM_PARTICLES
+          real(r8), intent(out) :: x(numel)
+          integer(i8) :: i
 
           do i = 1, numel
-            x(i) = real(i, kind = real64)
+            x(i) = real(i, kind = r8)
           end do
 
           return
@@ -160,44 +160,44 @@ c         NOTES:
 c         The constructor of the extending classes must invoke this subroutine, as you
 c         would do in C++ or Java.
           class(particle_t), intent(inout) :: particles
-          real(kind = real64), pointer, contiguous :: id(:) => null()
-          integer(kind = int64), parameter :: N = NUM_PARTICLES
+          real(r8), pointer, contiguous :: id(:) => null()
+          integer(i8), parameter :: N = NUM_PARTICLES
 c         size position vector
-          integer(kind = int64), parameter :: size_x = N
-          integer(kind = int64), parameter :: size_y = N
-          integer(kind = int64), parameter :: size_z = N
+          integer(i8), parameter :: size_x = N
+          integer(i8), parameter :: size_y = N
+          integer(i8), parameter :: size_z = N
 c         size Verlet displacement vector
-          integer(kind = int64), parameter :: size_Vdx = N
-          integer(kind = int64), parameter :: size_Vdy = N
-          integer(kind = int64), parameter :: size_Vdz = N
+          integer(i8), parameter :: size_Vdx = N
+          integer(i8), parameter :: size_Vdy = N
+          integer(i8), parameter :: size_Vdz = N
 c         size absolute position vector
-          integer(kind = int64), parameter :: size_r_x = N
-          integer(kind = int64), parameter :: size_r_y = N
-          integer(kind = int64), parameter :: size_r_z = N
+          integer(i8), parameter :: size_r_x = N
+          integer(i8), parameter :: size_r_y = N
+          integer(i8), parameter :: size_r_z = N
 c         size Euler angle vector
-          integer(kind = int64), parameter :: size_Eax = N
-          integer(kind = int64), parameter :: size_Eay = N
-          integer(kind = int64), parameter :: size_Eaz = N
+          integer(i8), parameter :: size_Eax = N
+          integer(i8), parameter :: size_Eay = N
+          integer(i8), parameter :: size_Eaz = N
 c         size director (or orientation) vector
-          integer(kind = int64), parameter :: size_d_x = N
-          integer(kind = int64), parameter :: size_d_y = N
-          integer(kind = int64), parameter :: size_d_z = N
+          integer(i8), parameter :: size_d_x = N
+          integer(i8), parameter :: size_d_y = N
+          integer(i8), parameter :: size_d_z = N
 c         size force vector
-          integer(kind = int64), parameter :: size_f_x = N
-          integer(kind = int64), parameter :: size_f_y = N
-          integer(kind = int64), parameter :: size_f_z = N
+          integer(i8), parameter :: size_f_x = N
+          integer(i8), parameter :: size_f_y = N
+          integer(i8), parameter :: size_f_z = N
 c         size torque vector
-          integer(kind = int64), parameter :: size_t_x = N
-          integer(kind = int64), parameter :: size_t_y = N
-          integer(kind = int64), parameter :: size_t_z = N
+          integer(i8), parameter :: size_t_x = N
+          integer(i8), parameter :: size_t_y = N
+          integer(i8), parameter :: size_t_z = N
 c         size temporary placeholder
-          integer(kind = int64), parameter :: size_tmp = 12_int64 * N
+          integer(i8), parameter :: size_tmp = 12_i8 * N
 c         size Verlet neighbor-list (NOTE: we shall allocate more later)
-          integer(kind = int64), parameter :: size_Vnl = N
+          integer(i8), parameter :: size_Vnl = N
 c         size particle identifiers IDs
-          integer(kind = int64), parameter :: size_id = N
+          integer(i8), parameter :: size_id = N
 c         sizes position vector
-          integer(kind = int64), parameter :: size_data = size_x +
+          integer(i8), parameter :: size_data = size_x +
      +                                                    size_y +
      +                                                    size_z +
 c         sizes Verlet displacement vector
@@ -231,24 +231,24 @@ c         sizes Verlet neighbor-list
 c         sizes particle identifiers IDs
      +                                                    size_id
 c         memory allocation status
-          integer(kind = int64) :: mstat
+          integer(i8) :: mstat
 c         size
-          integer(kind = int64) :: sz
+          integer(i8) :: sz
 
 c         complains if module `config' has illegal values
           call sane()
 
 c         allocates memory for the particle data
           allocate(particles % data(size_data), stat = mstat)
-          if (mstat /= 0_int64) then
+          if (mstat /= 0_i8) then
             error stop "particle::initializer(): allocation error"
           end if
 
 c         initializes the particle data with zeros
-          particles % data = 0.0_real64
+          particles % data = 0.0_r8
 
 c         position vector binding
-          sz = 0_int64
+          sz = 0_i8
           particles % x => particles % data(sz + 1:sz + size_x)
 
           sz = sz + size_x

--- a/api/fortran/module/random/random.f
+++ b/api/fortran/module/random/random.f
@@ -1,5 +1,5 @@
       module random
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: ieee_arithmetic, only: ieee_positive_inf
         use :: ieee_arithmetic, only: ieee_value
         implicit none
@@ -16,7 +16,7 @@
 c         Synopsis:
 c         Returns a uniformly distributed pseudo-random number in [0, 1).
 c         Forwards its task to the intrinsic `random_number()'.
-          real(kind = real64) :: x
+          real(r8) :: x
 
           call random_number(x)
 
@@ -28,30 +28,30 @@ c         Forwards its task to the intrinsic `random_number()'.
 c         Synopsis:
 c         Implements Böx-Muller's method.
 c         Yields a Normal (or Gaussian) Pseudo-Random Deviate (or Number).
-          real(kind = real64) :: positive_infinity
-          real(kind = real64) :: x1
-          real(kind = real64) :: x2
-          real(kind = real64) :: r
-          real(kind = real64) :: x
+          real(r8) :: positive_infinity
+          real(r8) :: x1
+          real(r8) :: x2
+          real(r8) :: r
+          real(r8) :: x
 
-          positive_infinity = ieee_value(0.0_real64,
+          positive_infinity = ieee_value(0.0_r8,
      +                                   ieee_positive_inf)
           r = positive_infinity
 c         NOTE: compiled with gfortran's -Wno-compare-reals, consider that if `r'
 c         is equal to zero that means that furand()'s underlying PRNG is bogus.
-          do while (r == 0.0_real64 .or. r > 1.0_real64)
+          do while (r == 0.0_r8 .or. r > 1.0_r8)
 
             x1 = furand()
             x2 = furand()
 
-            x1 = 2.0_real64 * x1 - 1.0_real64
-            x2 = 2.0_real64 * x2 - 1.0_real64
+            x1 = 2.0_r8 * x1 - 1.0_r8
+            x2 = 2.0_r8 * x2 - 1.0_r8
 
             r = x1**2 + x2**2
 
           end do
 
-          r = sqrt( ( -2.0_real64 * log(r) ) / r )
+          r = sqrt( ( -2.0_r8 * log(r) ) / r )
 
           x1 = r * x1
           x2 = r * x2

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -1,9 +1,9 @@
-#define __SUCCESS__  0_int64
-#define __FAILURE__ -1_int64
+#define __SUCCESS__  0_i8
+#define __FAILURE__ -1_i8
 
       module sphere
-        use, intrinsic :: iso_fortran_env, only: int64
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: LIMIT
         use :: config, only: LENGTH
         use :: config, only: INTERACT_ENABLE
@@ -50,14 +50,14 @@ c         Synopsis:
 c         Complains if it is not possible to stack the spheres in a grid (or lattice) like
 c         structure without incurring on particle overlaps.
 c         cubic system box length
-          real(kind = real64), parameter :: L = LENGTH
+          real(r8), parameter :: L = LENGTH
 c         sphere-contact distance
-          real(kind = real64), parameter :: C = CONTACT
+          real(r8), parameter :: C = CONTACT
 c         maximum number of spheres that can be stacked in one dimension 1D
-          integer(kind = int64), parameter :: max_num_stacked_1d =
-     +    floor(L / C, kind = int64)
+          integer(i8), parameter :: max_num_stacked_1d =
+     +    floor(L / C, kind = i8)
 c         maximum number of spheres that can be stacked in two dimensions 3D
-          integer(kind = int64), parameter :: max_num_stacked_3d =
+          integer(i8), parameter :: max_num_stacked_3d =
      +    (max_num_stacked_1d ** 3)
 c         error message
           character(*), parameter :: errmsg = "sphere::stackable(): "//
@@ -91,30 +91,29 @@ c         NOTE:
 c         The computed  `x' coordinates RHS increment on each iteration until a stack
 c         is completed, and in that instance the computed `x' coordinate is set to zero.
 c         array of `x'-coordinates of the spheres
-          real(kind = real64), intent(out) :: x(NUM_SPHERES)
+          real(r8), intent(out) :: x(NUM_SPHERES)
 c         uses offset to ensure no particle overlaps across boundaries
-          real(kind = real64), parameter :: offset = RADIUS
+          real(r8), parameter :: offset = RADIUS
 c         cubic system box length
-          real(kind = real64), parameter :: L = LENGTH
+          real(r8), parameter :: L = LENGTH
 c         sphere-contact distance
-          real(kind = real64), parameter :: C = CONTACT
+          real(r8), parameter :: C = CONTACT
 c         maximum number of spheres that can be stacked in one dimension 1D
-          integer(kind = int64), parameter :: max_stacked = floor(L / C,
-     +    kind = int64)
+          integer(i8), parameter :: max_stacked = floor(L / C, kind=i8)
 c         particle counter
-          integer(kind = int64) :: counter
+          integer(i8) :: counter
 c         particle id
-          integer(kind = int64) :: id
+          integer(i8) :: id
 c         index
-          integer(kind = int64) :: i
+          integer(i8) :: i
 
 c         loop-invariant: so far we have updated the `x' position of `counter' spheres
-          counter = 0_int64
+          counter = 0_i8
           do while (counter /= NUM_SPHERES)
-            id = counter + 1_int64
+            id = counter + 1_i8
             i = mod(counter, max_stacked)
-            x(id) = offset + CONTACT * real(i, kind = real64)
-            counter = counter + 1_int64
+            x(id) = offset + CONTACT * real(i, kind = r8)
+            counter = counter + 1_i8
           end do
 
           return
@@ -130,37 +129,37 @@ c         NOTE:
 c         The computed `y' coordinates RHS increment when a stack is completed, the
 c         `y' coordinate gets reseted upon filling an entire area (in the x-y plane).
 c         array of `y'-coordinates of the spheres
-          real(kind = real64), intent(out) :: y(NUM_SPHERES)
+          real(r8), intent(out) :: y(NUM_SPHERES)
 c         uses offset to ensure no particle overlaps across boundaries
-          real(kind = real64), parameter :: offset = RADIUS
+          real(r8), parameter :: offset = RADIUS
 c         cubic system box length
-          real(kind = real64), parameter :: L = LENGTH
+          real(r8), parameter :: L = LENGTH
 c         sphere-contact distance
-          real(kind = real64), parameter :: C = CONTACT
+          real(r8), parameter :: C = CONTACT
 c         maximum number of spheres that can be stacked in one dimension 1D
-          integer(kind = int64), parameter :: max_num_stacked_1d =
-     +    floor(L / C, kind = int64)
-          integer(kind = int64), parameter :: max_num_stacked_2d =
+          integer(i8), parameter :: max_num_stacked_1d =
+     +    floor(L / C, kind = i8)
+          integer(i8), parameter :: max_num_stacked_2d =
      +    (max_num_stacked_1d ** 2)
 c         alias
-          integer(kind = int64), parameter :: stacked_1d =
+          integer(i8), parameter :: stacked_1d =
      +    max_num_stacked_1d
 c         alias
-          integer(kind = int64), parameter :: stacked_2d =
+          integer(i8), parameter :: stacked_2d =
      +    max_num_stacked_2d
-          integer(kind = int64) :: counter
+          integer(i8) :: counter
 c         particle id
-          integer(kind = int64) :: id
+          integer(i8) :: id
 c         index
-          integer(kind = int64) :: i
+          integer(i8) :: i
 
 c         loop-invariant: so far we have updated the `y' position of `counter' spheres
-          counter = 0_int64
+          counter = 0_i8
           do while (counter /= NUM_SPHERES)
-            id = counter + 1_int64
+            id = counter + 1_i8
             i = mod(counter, stacked_2d) / stacked_1d
-            y(id) = offset + CONTACT * real(i, kind = real64)
-            counter = counter + 1_int64
+            y(id) = offset + CONTACT * real(i, kind = r8)
+            counter = counter + 1_i8
           end do
 
           return
@@ -174,36 +173,36 @@ c         We can say this because we have already called `stack_x()' and `stack_
 c         NOTE:
 c         The computed `z' coordinates increment upon filling an area (in the x-y plane).
 c         array of `z'-coordinates of the spheres
-          real(kind = real64), intent(out) :: z(NUM_SPHERES)
+          real(r8), intent(out) :: z(NUM_SPHERES)
 c         uses offset to ensure no particle overlaps across boundaries
-          real(kind = real64), parameter :: offset = RADIUS
+          real(r8), parameter :: offset = RADIUS
 c         cubic system box length
-          real(kind = real64), parameter :: L = LENGTH
+          real(r8), parameter :: L = LENGTH
 c         sphere-contact distance
-          real(kind = real64), parameter :: C = CONTACT
+          real(r8), parameter :: C = CONTACT
 c         maximum number of spheres that can be stacked in one dimension 1D
-          integer(kind = int64), parameter :: max_num_stacked_1d =
-     +    floor(L / C, kind = int64)
+          integer(i8), parameter :: max_num_stacked_1d =
+     +    floor(L / C, kind = i8)
 c         maximum number of spheres that can be stacked in two dimensions 2D
-          integer(kind = int64), parameter :: max_num_stacked_2d =
+          integer(i8), parameter :: max_num_stacked_2d =
      +    (max_num_stacked_1d ** 2)
 c         alias
-          integer(kind = int64), parameter :: stacked_2d =
+          integer(i8), parameter :: stacked_2d =
      +    max_num_stacked_2d
 c         particle counter
-          integer(kind = int64) :: counter
+          integer(i8) :: counter
 c         particle id
-          integer(kind = int64) :: id
+          integer(i8) :: id
 c         index
-          integer(kind = int64) :: i
+          integer(i8) :: i
 
 c         loop-invariant: so far we have updated the `z' position of `counter' spheres
-          counter = 0_int64
+          counter = 0_i8
           do while (counter /= NUM_SPHERES)
-            id = counter + 1_int64
+            id = counter + 1_i8
             i = counter / stacked_2d
-            z(id) = offset + CONTACT * real(i, kind = real64)
-            counter = counter + 1_int64
+            z(id) = offset + CONTACT * real(i, kind = r8)
+            counter = counter + 1_i8
           end do
 
           return
@@ -215,9 +214,9 @@ c         Synopsis:
 c         Places the spheres in a grid (or lattice) like structure.
           type(sphere_t), target, intent(inout) :: spheres
 c         pointers to the position vector components
-          real(kind = real64), pointer, contiguous :: x(:)
-          real(kind = real64), pointer, contiguous :: y(:)
-          real(kind = real64), pointer, contiguous :: z(:)
+          real(r8), pointer, contiguous :: x(:)
+          real(r8), pointer, contiguous :: y(:)
+          real(r8), pointer, contiguous :: z(:)
 
           x => spheres % x
 
@@ -253,10 +252,10 @@ c         Logs the current particle fields (or properties) to a plain text file.
 c         Forwards the task to IO logger utility.
           class(sphere_t), intent(in) :: particles
 c         OBDS simulation step number (or identifier)
-          integer(kind = int64), intent(in) :: step
+          integer(i8), intent(in) :: step
 c         status of the IO operation
-          integer(kind = int64) :: status
-          integer(kind = int64) :: istate
+          integer(i8) :: status
+          integer(i8) :: istate
 
           status = io__flogger(particles, step)
           if (STATUS == __FAILURE__) then
@@ -284,15 +283,15 @@ c         Synopsis:
 c         Tries to load the particle fields (or properties) from the state file.
 c         Returns the status of the IO operation.
           class(sphere_t), pointer, intent(inout) :: particles
-          real(kind = real64), pointer, contiguous :: tmp(:) => null()
+          real(r8), pointer, contiguous :: tmp(:) => null()
 c         IO status
-          integer(kind = int64) :: status
+          integer(i8) :: status
 c         the state is the simulation step number
-          integer(kind = int64) :: istate
+          integer(i8) :: istate
 
 c         reads the state (since the caller method has fetched it for us)
           tmp => particles % tmp
-          istate = int(tmp(1), kind = int64)
+          istate = int(tmp(1), kind = i8)
 c         loads the particle fields (or properties) from the respective state file
           status = io__floader(particles, istate)
 
@@ -330,8 +329,8 @@ c         that and have regretted all the time spent trying to figure out why it
 c         work and how to fix it). We are open to reconsider our position if the standard
 c         provides a better solution than our workaround in the future.
           class(sphere_t), pointer :: spheres
-          integer(kind = int64) :: status
-          integer(kind = int64) :: mstat
+          integer(i8) :: status
+          integer(i8) :: mstat
 
 c         performs sane-checks
           call sane()
@@ -339,7 +338,7 @@ c         performs sane-checks
 c         memory allocations:
           spheres => null()
           allocate(spheres, stat = mstat)
-          if (mstat /= 0_int64) then
+          if (mstat /= 0_i8) then
             error stop "sphere_t(): memory allocation error"
           end if
 
@@ -385,7 +384,7 @@ c         applies Periodic Boundary Conditions
         pure subroutine callback (particles, i)
 c         enables Shifted Lennard-Jones SLJ particle-particle interactions
           class(sphere_t), intent(inout) :: particles
-          integer(kind = int64), intent(in) :: i
+          integer(i8), intent(in) :: i
 
           call force__callback_SLJ_handler(particles, i)
 
@@ -397,7 +396,7 @@ c         enables Shifted Lennard-Jones SLJ particle-particle interactions
 c         Synopsis:
 c         Frees resources allocated for the spheres.
           type(sphere_t), intent(inout) :: spheres
-          integer(kind = int64) :: mstat
+          integer(i8) :: mstat
           character(*), parameter :: errmsg =
      +    "sphere::destructor(): unexpected memory deallocation error"
 
@@ -405,7 +404,7 @@ c         Frees resources allocated for the spheres.
 
             deallocate(spheres % data, stat = mstat)
 
-            if (mstat /= 0_int64) then
+            if (mstat /= 0_i8) then
               error stop errmsg
             end if
 

--- a/api/fortran/module/system/system.f
+++ b/api/fortran/module/system/system.f
@@ -1,5 +1,5 @@
       module system
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: N => NUM_PARTICLES
         use :: config, only: L => LENGTH
         use :: particle, only: particle_t
@@ -16,7 +16,7 @@
         pure subroutine update_position_vector_component (x)
 c         Synopsis:
 c         Updates the position vector component by applying periodic boundary conditions.
-          real(kind = real64), intent(inout) :: x(N)
+          real(r8), intent(inout) :: x(N)
 
           x = x - anint(x / L) * L
 
@@ -27,9 +27,9 @@ c         Updates the position vector component by applying periodic boundary co
         pure subroutine update_position_vector (x, y, z)
 c         Synopsis:
 c         Updates the position vectors by applying periodic boundary conditions.
-          real(kind = real64), intent(inout) :: x(N)
-          real(kind = real64), intent(inout) :: y(N)
-          real(kind = real64), intent(inout) :: z(N)
+          real(r8), intent(inout) :: x(N)
+          real(r8), intent(inout) :: y(N)
+          real(r8), intent(inout) :: z(N)
 
           call update_position_vector_component(x)
           call update_position_vector_component(y)
@@ -44,9 +44,9 @@ c         Synopsis:
 c         Updates the position vectors of the particles by applying periodic boundary
 c         conditions.
           class(particle_t), intent(inout), target :: particles
-          real(kind = real64), pointer, contiguous :: x(:)
-          real(kind = real64), pointer, contiguous :: y(:)
-          real(kind = real64), pointer, contiguous :: z(:)
+          real(r8), pointer, contiguous :: x(:)
+          real(r8), pointer, contiguous :: y(:)
+          real(r8), pointer, contiguous :: z(:)
 
           x => particles % x
           y => particles % y

--- a/api/fortran/module/timer/timer.f
+++ b/api/fortran/module/timer/timer.f
@@ -1,14 +1,14 @@
       module timer
-        use, intrinsic :: iso_fortran_env, only: int64
+        use, intrinsic :: iso_fortran_env, only: i8 => int64
         use :: config, only: WALLTIME ! OBDS App WALLTIME [seconds]
         implicit none
         private
 
         type, public :: timer_t
           private
-          integer(kind = int64) :: resolution = 0_int64
-          integer(kind = int64) :: time_start = 0_int64
-          integer(kind = int64) :: time_end   = 0_int64
+          integer(i8) :: resolution = 0_i8
+          integer(i8) :: time_start = 0_i8
+          integer(i8) :: time_end   = 0_i8
           contains
             private
             procedure :: t_fgetetime => timer_fgetetime
@@ -27,7 +27,7 @@
       contains
 
         function ftime () result(t)
-          integer(kind = int64) :: t
+          integer(i8) :: t
 
           call system_clock(count = t)
 
@@ -36,7 +36,7 @@
 
         subroutine timer_start (this)
           class(timer_t), intent(inout) :: this
-          integer(kind = int64) :: time_start
+          integer(i8) :: time_start
 
           time_start = ftime()
           call this % t_start_setter(time_start)
@@ -47,7 +47,7 @@
 
         subroutine timer_end (this)
           class(timer_t), intent(inout) :: this
-          integer(kind = int64) :: time_end
+          integer(i8) :: time_end
 
           time_end = ftime()
           call this % t_end_setter(time_end)
@@ -58,7 +58,7 @@
 
         pure subroutine timer_start_setter (this, time_start)
           class(timer_t), intent(inout) :: this
-          integer(kind = int64), intent(in) :: time_start
+          integer(i8), intent(in) :: time_start
 
           this % time_start = time_start
 
@@ -68,7 +68,7 @@
 
         pure subroutine timer_end_setter (this, time_end)
           class(timer_t), intent(inout) :: this
-          integer(kind = int64), intent(in) :: time_end
+          integer(i8), intent(in) :: time_end
 
           this % time_end = time_end
 
@@ -78,10 +78,10 @@
 
         pure function timer_fgetetime (this) result(etime)
           class(timer_t), intent(in) :: this
-          integer(kind = int64) :: etime
-          integer(kind = int64) :: time_start
-          integer(kind = int64) :: time_end
-          integer(kind = int64) :: time_elapsed
+          integer(i8) :: etime
+          integer(i8) :: time_start
+          integer(i8) :: time_end
+          integer(i8) :: time_elapsed
 
           time_start = this % time_start
           time_end = this % time_end
@@ -96,10 +96,10 @@
 c         Synopsis:
 c         Sets the alarm if the walltime has been reached.
           class(timer_t), intent(in) :: this
-          logical(kind = int64) :: enabled
-          integer(kind = int64) :: resolution
-          integer(kind = int64) :: time_elapsed
-          integer(kind = int64) :: wtime
+          logical(i8) :: enabled
+          integer(i8) :: resolution
+          integer(i8) :: time_elapsed
+          integer(i8) :: wtime
 
           time_elapsed = this % t_fgetetime()
 
@@ -118,12 +118,12 @@ c         converts seconds to whatever time-unit (millis, us, ns) `system_clock(
 
         function constructor () result(timer)
           type(timer_t) :: timer
-          integer(kind = int64) :: system_clock__resolution
+          integer(i8) :: system_clock__resolution
 
           call system_clock(count_rate = system_clock__resolution)
           timer % resolution = system_clock__resolution
-          timer % time_start = 0_int64
-          timer % time_end   = 0_int64
+          timer % time_start = 0_i8
+          timer % time_end   = 0_i8
 
           return
         end function constructor

--- a/api/fortran/module/vector/vector.f
+++ b/api/fortran/module/vector/vector.f
@@ -1,5 +1,5 @@
       module vector
-        use, intrinsic :: iso_fortran_env, only: real64
+        use, intrinsic :: iso_fortran_env, only: r8 => real64
         use :: config, only: N => NUM_PARTICLES
         implicit none
         private
@@ -29,12 +29,12 @@
         pure subroutine vec (x, y, z, v_x, v_y, v_z)
 c         Synopsis:
 c         Vectorizer.
-          real(kind = real64), intent(in) :: x
-          real(kind = real64), intent(in) :: y
-          real(kind = real64), intent(in) :: z
-          real(kind = real64), intent(out) :: v_x(N)
-          real(kind = real64), intent(out) :: v_y(N)
-          real(kind = real64), intent(out) :: v_z(N)
+          real(r8), intent(in) :: x
+          real(r8), intent(in) :: y
+          real(r8), intent(in) :: z
+          real(r8), intent(out) :: v_x(N)
+          real(r8), intent(out) :: v_y(N)
+          real(r8), intent(out) :: v_z(N)
 
           v_x = x
           v_y = y
@@ -47,9 +47,9 @@ c         Vectorizer.
         elemental subroutine add_elem (x1, x2, x3)
 c         Synopsis:
 c         Implements vector addition.
-          real(kind = real64), intent(in) :: x1
-          real(kind = real64), intent(in) :: x2
-          real(kind = real64), intent(out) :: x3
+          real(r8), intent(in) :: x1
+          real(r8), intent(in) :: x2
+          real(r8), intent(out) :: x3
           
           x3 = (x1 + x2)
 
@@ -60,9 +60,9 @@ c         Implements vector addition.
         elemental subroutine diff_elem (x1, x2, x3)
 c         Synopsis:
 c         Implements vector difference.
-          real(kind = real64), intent(in) :: x1
-          real(kind = real64), intent(in) :: x2
-          real(kind = real64), intent(out) :: x3
+          real(r8), intent(in) :: x1
+          real(r8), intent(in) :: x2
+          real(r8), intent(out) :: x3
 
           x3 = (x2 - x1)
 
@@ -74,11 +74,11 @@ c         Implements vector difference.
 c         Synopsis:
 c         Implements vector norm.
 c         vector components
-          real(kind = real64), intent(in) :: x
-          real(kind = real64), intent(in) :: y
-          real(kind = real64), intent(in) :: z
+          real(r8), intent(in) :: x
+          real(r8), intent(in) :: y
+          real(r8), intent(in) :: z
 c         squared vector norm
-          real(kind = real64), intent(out) :: vn
+          real(r8), intent(out) :: vn
 
           vn = x**2 + y**2 + z**2
 
@@ -100,17 +100,17 @@ c         squared vector norm
 c         Synopsis:
 c         Implements vector addition.
 c         components of vector v1
-          real(kind = real64), intent(in) :: u_x(N)
-          real(kind = real64), intent(in) :: u_y(N)
-          real(kind = real64), intent(in) :: u_z(N)
+          real(r8), intent(in) :: u_x(N)
+          real(r8), intent(in) :: u_y(N)
+          real(r8), intent(in) :: u_z(N)
 c         components of vector v2
-          real(kind = real64), intent(in) :: v_x(N)
-          real(kind = real64), intent(in) :: v_y(N)
-          real(kind = real64), intent(in) :: v_z(N)
+          real(r8), intent(in) :: v_x(N)
+          real(r8), intent(in) :: v_y(N)
+          real(r8), intent(in) :: v_z(N)
 c         components of vector v3
-          real(kind = real64), intent(out) :: w_x(N)
-          real(kind = real64), intent(out) :: w_y(N)
-          real(kind = real64), intent(out) :: w_z(N)
+          real(r8), intent(out) :: w_x(N)
+          real(r8), intent(out) :: w_y(N)
+          real(r8), intent(out) :: w_z(N)
 
           call add_elem(u_x, v_x, w_x)
           call add_elem(u_y, v_y, w_y)
@@ -135,17 +135,17 @@ c         Synopsis:
 c         Synopsis:
 c         Implements vector difference.
 c         components of vector v1
-          real(kind = real64), intent(in) :: u_x(N)
-          real(kind = real64), intent(in) :: u_y(N)
-          real(kind = real64), intent(in) :: u_z(N)
+          real(r8), intent(in) :: u_x(N)
+          real(r8), intent(in) :: u_y(N)
+          real(r8), intent(in) :: u_z(N)
 c         components of vector v2
-          real(kind = real64), intent(in) :: v_x(N)
-          real(kind = real64), intent(in) :: v_y(N)
-          real(kind = real64), intent(in) :: v_z(N)
+          real(r8), intent(in) :: v_x(N)
+          real(r8), intent(in) :: v_y(N)
+          real(r8), intent(in) :: v_z(N)
 c         components of vector v3
-          real(kind = real64), intent(out) :: w_x(N)
-          real(kind = real64), intent(out) :: w_y(N)
-          real(kind = real64), intent(out) :: w_z(N)
+          real(r8), intent(out) :: w_x(N)
+          real(r8), intent(out) :: w_y(N)
+          real(r8), intent(out) :: w_z(N)
 
           call diff_elem(u_x, v_x, w_x)
           call diff_elem(u_y, v_y, w_y)
@@ -159,13 +159,13 @@ c         components of vector v3
 c         Synopsis:
 c         Implements vector norm.
 c         vector components
-          real(kind = real64), intent(in) :: x(N)
-          real(kind = real64), intent(in) :: y(N)
-          real(kind = real64), intent(in) :: z(N)
+          real(r8), intent(in) :: x(N)
+          real(r8), intent(in) :: y(N)
+          real(r8), intent(in) :: z(N)
 c         array temporary storing the squares (that is, x**2 + y**2 + z**2)
-          real(kind = real64), intent(out) :: squares(N)
+          real(r8), intent(out) :: squares(N)
 c         vector norm
-          real(kind = real64), intent(out) :: vnorm(N)
+          real(r8), intent(out) :: vnorm(N)
 
           call norm_elem(x, y, z, squares)
 


### PR DESCRIPTION
renames for readability

Linux kernel developers use those abbreviations as well