### PR TITLE
partitions dynamic into submodule [FORTRAN]

### DIFF
--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -20,6 +20,8 @@
         public :: INTERACT_ENABLE
         public :: PENDING
         public :: DONE
+        public :: BROWNIAN
+        public :: DETERMINISTIC
 
 
 **                                                                    **
@@ -39,6 +41,16 @@
 *       `done' status is dumped by the OBDS code when the simulation   *
 *       finishes, that happens when the step counter is equal to the   *
 *       total number of steps, NUM_STEPS.                              *
+**                                                                    **
+
+
+**                                                                    **
+*       Brownian and deterministic modes of translation                *
+        enum, bind(c)
+          enumerator :: BROWNIAN
+          enumerator :: DETERMINISTIC
+        end enum
+*                                                                      *
 **                                                                    **
 
 

--- a/api/fortran/module/sphere/sphere.f
+++ b/api/fortran/module/sphere/sphere.f
@@ -12,6 +12,8 @@
         use :: config, only: CONTACT => SPH_CONTACT
         use :: config, only: NUM_SPHERES => NUM_PARTICLES
         use :: config, only: NUM_STEPS
+        use :: config, only: DETERMINISTIC
+        use :: config, only: BROWNIAN
         use :: config, only: PENDING
         use :: config, only: DONE
         use :: io, only: io__flogger
@@ -24,7 +26,6 @@
         use :: force, only: force__callback_SLJ_handler
         use :: system, only: system__PBC
         use :: dynamic, only: dynamic__translator
-        use :: dynamic, only: dynamic__shifter
         use :: particle, only: particle_t
         implicit none
         private
@@ -369,13 +370,11 @@ c         Implements Brownian spheres.
 
           if (INTERACT_ENABLE) then
             call force__brute_force(particles)
-            call dynamic__translator(particles)
+            call dynamic__translator(particles, MODE = DETERMINISTIC)
           end if
-c         computes Brownian forces
+
           call force__Brownian_force(particles)
-c         shifts particles Brownianly
-          call dynamic__shifter(particles)
-c         applies Periodic Boundary Conditions
+          call dynamic__translator(particles, MODE = BROWNIAN)
           call system__PBC(particles)
 
           return


### PR DESCRIPTION
COMMENTS:
the partitioning improves code reusability, readability, and maintainability

this change exposes the implementation used to translate the particles in a straightforward way