### PR TITLE
adds resistance matrix sane check [FORTRAN]

### DIFF
--- a/api/fortran/module/config/config.f
+++ b/api/fortran/module/config/config.f
@@ -22,6 +22,7 @@
         public :: DONE
         public :: BROWNIAN
         public :: DETERMINISTIC
+        public :: ISOTROPIC
 
 
 **                                                                    **
@@ -50,6 +51,13 @@
           enumerator :: BROWNIAN
           enumerator :: DETERMINISTIC
         end enum
+*                                                                      *
+**                                                                    **
+
+
+**                                                                    **
+*      isotropic | anistropic particle microhydrodynamics              *
+       logical(i8), parameter :: ISOTROPIC = .true.
 *                                                                      *
 **                                                                    **
 


### PR DESCRIPTION
COMMENTS:
adds resistance matrix sane check

OBDS aims to simulate particles with isotropic (spheres) and anisotropic (spheroids of revolution) resistance matrices so this is a step towards that.

We want to make sure that the code is configured properly, it would be an error to configure spheres with anisotropic hydrodynamic resistances (or spheroids of revolution with isotropic ones).

One could argue that this check is totally unnecessary that this could be done dynamically based on the particle types so that the right method gets called during runtime or that the whole point of OOP is to leverage on polymorphism.

I have chosen to do this in this way so that the optimizer will eliminate all together the calls to the methods that do not apply to the particle type at compile time. Doing this not out of performance concerns but because I want to structure my code in my own way because I have the freedom to do so regardless of what other devs think about this approach. (Some will agree and others will not whatever the path chosen so I will do it my way.)

The real advantage of doing this in my way is that we shall be able to catch on errors due to possible misconfigurations quickly. This has a lot of value during development, later on we can follow whatever practices are generally accepted at the time.